### PR TITLE
Add STM32RTC library source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # STM32RTC
 A RTC library for STM32.
+
+# API
+
+This library is based on the Arduino RTCZero library.
+The library allows to take control of the internal RTC of the STM32 boards.
+
+The following functions are not supported:
+
+* **`void standbyMode()`**: use the STM32 Low Power library instead.
+* **`uint8_t getAlarmMonth()`**: month not supported by STM32 RTC architecture.
+* **`uint8_t getAlarmYear()`**: year not supported by STM32 RTC architecture.
+* **`void setAlarmMonth(uint8_t month)`**: month not supported by STM32 RTC architecture.
+* **`void setAlarmYear(uint8_t year)`**: year not supported by STM32 RTC architecture.
+* **`void setAlarmDate(uint8_t day, uint8_t month, uint8_t year)`**: month and year not supported by STM32 RTC architecture.
+
+The following functions have been added to support specific STM32 RTC features:
+
+_RTC hours mode (12 or 24)_
+* **`void begin(RTCHourFormats_t format)`**
+
+_RTC clock source_
+* **`void setClockSource(sourceClock_t source)`** : this function must be called before `begin()`
+
+_SubSeconds management_
+* **`uint32_t getSubSeconds(void)`**
+* **`void setSubSeconds(uint32_t subSeconds)`**
+
+_Hour format (AM or PM)_
+* **`uint8_t getHours(Hour12_AM_PM_t *format)`**
+* **`void setHours(uint8_t hours, Hour12_AM_PM_t format)`**
+* **`void setTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, Hour12_AM_PM_t format)`**
+* **`void setAlarmHours(uint8_t hours, Hour12_AM_PM_t format)`**
+* **`uint8_t getAlarmHours(Hour12_AM_PM_t *format)`**
+* **`void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, Hour12_AM_PM_t format)`**
+
+_Week day configuration_
+* **`uint8_t getWeekDay(void)`**
+* **`void setWeekDay(uint8_t weekDay)`**
+* **`void setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year)`**
+
+Refer to the Arduino RTC documentation for the other functions  
+http://arduino.cc/en/Reference/RTC
+
+## Source
+
+Source files available at:  
+https://github.com/stm32duino/STM32RTC

--- a/examples/Epoch/Epoch.ino
+++ b/examples/Epoch/Epoch.ino
@@ -1,0 +1,84 @@
+/**
+  ******************************************************************************
+  * @file    Epoch.ino
+  * @author  WI6LABS
+  * @version V1.0.0
+  * @date    12-December-2017
+  * @brief   RTC epoch example
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+#include <STM32RTC.h>
+
+/* Create a rtc object */
+STM32RTC rtc;
+
+void setup() {
+  Serial.begin(9600);
+
+  rtc.begin(); // initialize RTC 24H format
+
+  rtc.setEpoch(1451606400); // Jan 1, 2016
+}
+
+void loop() {
+  Serial.print("Unix time = ");
+  Serial.println(rtc.getEpoch());
+
+  Serial.print("Seconds since Jan 1 2000 = ");
+  Serial.println(rtc.getY2kEpoch());
+
+  // Print date...
+  Serial.print(rtc.getDay());
+  Serial.print("/");
+  Serial.print(rtc.getMonth());
+  Serial.print("/");
+  Serial.print(rtc.getYear());
+  Serial.print("\t");
+
+  // ...and time
+  print2digits(rtc.getHours());
+  Serial.print(":");
+  print2digits(rtc.getMinutes());
+  Serial.print(":");
+  print2digits(rtc.getSeconds());
+
+  Serial.println();
+
+  delay(1000);
+}
+
+void print2digits(int number) {
+  if (number < 10) {
+    Serial.print("0");
+  }
+  Serial.print(number);
+}

--- a/examples/RTCClockSelection/RTCClockSelection.ino
+++ b/examples/RTCClockSelection/RTCClockSelection.ino
@@ -1,0 +1,112 @@
+/**
+  ******************************************************************************
+  * @file    RTCClockSelection.ino
+  * @author  WI6LABS
+  * @version V1.0.0
+  * @date    15-March-2018
+  * @brief   RTC clock selection: LSI, LSE or HSE. Refer to board datasheet to
+  *          know available clock.
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+#include <STM32RTC.h>
+
+/* Create a rtc object */
+STM32RTC rtc;
+
+/* Change these values to set the current initial time */
+const byte seconds = 0;
+const byte minutes = 0;
+const byte hours = 16;
+
+/* Change these values to set the current initial date */
+/* Monday 15th June 2015 */
+const byte weekDay = 1;
+const byte day = 15;
+const byte month = 6;
+const byte year = 15;
+
+void setup()
+{
+  Serial.begin(9600);
+
+  // Select RTC clock source: RTC_LSI_CLOCK, RTC_LSE_CLOCK or RTC_HSE_CLOCK.
+  // By default the LSI is selected as source.
+  rtc.setClockSource(RTC_LSE_CLOCK);
+
+  rtc.begin(); // initialize RTC 24H format
+
+  // Set the time
+  rtc.setHours(hours);
+  rtc.setMinutes(minutes);
+  rtc.setSeconds(seconds);
+
+  // Set the date
+  rtc.setWeekDay(weekDay);
+  rtc.setDay(day);
+  rtc.setMonth(month);
+  rtc.setYear(year);
+
+  // you can use also
+  //rtc.setTime(hours, minutes, seconds);
+  //rtc.setDate(weekDay, day, month, year);
+}
+
+void loop()
+{
+  // Print date...
+  print2digits(rtc.getDay());
+  Serial.print("/");
+  print2digits(rtc.getMonth());
+  Serial.print("/");
+  print2digits(rtc.getYear());
+  Serial.print(" ");
+
+  // ...and time
+  print2digits(rtc.getHours());
+  Serial.print(":");
+  print2digits(rtc.getMinutes());
+  Serial.print(":");
+  print2digits(rtc.getSeconds());
+
+  Serial.println();
+
+  delay(1000);
+}
+
+
+
+void print2digits(int number) {
+  if (number < 10) {
+    Serial.print("0"); // print a 0 before if the number is < than 10
+  }
+  Serial.print(number);
+}

--- a/examples/SimpleRTC/SimpleRTC.ino
+++ b/examples/SimpleRTC/SimpleRTC.ino
@@ -1,0 +1,107 @@
+/**
+  ******************************************************************************
+  * @file    SimpleRTC.ino
+  * @author  WI6LABS
+  * @version V1.0.0
+  * @date    12-December-2017
+  * @brief   Simple RTC example.
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+#include <STM32RTC.h>
+
+/* Create a rtc object */
+STM32RTC rtc;
+
+/* Change these values to set the current initial time */
+const byte seconds = 0;
+const byte minutes = 0;
+const byte hours = 16;
+
+/* Change these values to set the current initial date */
+/* Monday 15th June 2015 */
+const byte weekDay = 1;
+const byte day = 15;
+const byte month = 6;
+const byte year = 15;
+
+void setup()
+{
+  Serial.begin(9600);
+
+  rtc.begin(); // initialize RTC 24H format
+
+  // Set the time
+  rtc.setHours(hours);
+  rtc.setMinutes(minutes);
+  rtc.setSeconds(seconds);
+
+  // Set the date
+  rtc.setWeekDay(weekDay);
+  rtc.setDay(day);
+  rtc.setMonth(month);
+  rtc.setYear(year);
+
+  // you can use also
+  //rtc.setTime(hours, minutes, seconds);
+  //rtc.setDate(weekDay, day, month, year);
+}
+
+void loop()
+{
+  // Print date...
+  print2digits(rtc.getDay());
+  Serial.print("/");
+  print2digits(rtc.getMonth());
+  Serial.print("/");
+  print2digits(rtc.getYear());
+  Serial.print(" ");
+
+  // ...and time
+  print2digits(rtc.getHours());
+  Serial.print(":");
+  print2digits(rtc.getMinutes());
+  Serial.print(":");
+  print2digits(rtc.getSeconds());
+
+  Serial.println();
+
+  delay(1000);
+}
+
+
+
+void print2digits(int number) {
+  if (number < 10) {
+    Serial.print("0"); // print a 0 before if the number is < than 10
+  }
+  Serial.print(number);
+}

--- a/examples/simpleRTCAlarm/simpleRTCAlarm.ino
+++ b/examples/simpleRTCAlarm/simpleRTCAlarm.ino
@@ -1,0 +1,77 @@
+/**
+  ******************************************************************************
+  * @file    simpleRTCAlarm.ino
+  * @author  WI6LABS
+  * @version V1.0.0
+  * @date    12-December-2017
+  * @brief   Simple RTC with alarm example.
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+#include <STM32RTC.h>
+
+/* Create a rtc object */
+STM32RTC rtc;
+
+/* Change these values to set the current initial time */
+const byte seconds = 0;
+const byte minutes = 0;
+const byte hours = 16;
+
+/* Change these values to set the current initial date */
+const byte day = 25;
+const byte month = 9;
+const byte year = 15;
+
+void setup()
+{
+  Serial.begin(9600);
+
+  rtc.begin(); // initialize RTC 24H format
+
+  rtc.setTime(hours, minutes, seconds);
+  rtc.setDate(day, month, year);
+
+  rtc.attachInterrupt(alarmMatch);
+  rtc.setAlarmDay(day);
+  rtc.setAlarmTime(16, 0, 10);
+  rtc.enableAlarm(rtc.MATCH_DHHMMSS);
+}
+
+void loop()
+{
+
+}
+
+void alarmMatch(void *data)
+{
+  Serial.println("Alarm Match!");
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,75 @@
+#######################################
+# Syntax Coloring Map For RTC
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+STM32RTC	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+getWeekDay		KEYWORD2
+getDay			KEYWORD2
+getMonth		KEYWORD2
+getYear			KEYWORD2
+getHours		KEYWORD2
+getMinutes		KEYWORD2
+getSeconds 		KEYWORD2
+getSubSeconds		KEYWORD2
+
+setWeekDay		KEYWORD2
+setDay			KEYWORD2
+setMonth		KEYWORD2
+setYear			KEYWORD2
+setHours 		KEYWORD2
+setMinutes		KEYWORD2
+setSeconds 		KEYWORD2
+setSubSeconds		KEYWORD2
+setDate			KEYWORD2
+setTime			KEYWORD2
+
+getEpoch		KEYWORD2
+getY2kEpoch		KEYWORD2
+setEpoch		KEYWORD2
+setY2kEpoch		KEYWORD2
+setAlarmEpoch		KEYWORD2
+
+getAlarmDay		KEYWORD2
+getAlarmHours 		KEYWORD2
+getAlarmMinutes		KEYWORD2
+getAlarmSeconds 	KEYWORD2
+getAlarmSubSeconds	KEYWORD2
+
+setAlarmSeconds		KEYWORD2
+setAlarmMinutes		KEYWORD2
+setAlarmHours		KEYWORD2
+setAlarmHours		KEYWORD2
+setAlarmTime		KEYWORD2
+setAlarmTime		KEYWORD2
+setAlarmDay		KEYWORD2
+setAlarmMonth		KEYWORD2
+setAlarmYear		KEYWORD2
+setAlarmDate		KEYWORD2
+
+enableAlarm 		KEYWORD2
+disableAlarm 		KEYWORD2
+
+attachInterrupt		KEYWORD2
+detachInterrupt		KEYWORD2
+
+setClockSource		KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+HOUR_12	LITERAL1
+HOUR_24	LITERAL1
+HOUR_AM	LITERAL1
+HOUR_PM	LITERAL1
+RTC_LSE_CLOCK	LITERAL1
+RTC_LSI_CLOCK	LITERAL1
+RTC_HSE_CLOCK	LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=STM32duino RTC
+version=1.0.0
+author=Wi6Labs
+maintainer=stm32duino
+sentence=Allows to use the RTC functionalities. For STM32 boards.
+paragraph=With this library you can use the RTC peripheral in order to program actions related to date and time.
+category=Timing
+url=https://github.com/stm32duino/STM32RTC.git
+architectures=stm32

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -1,0 +1,855 @@
+/**
+  ******************************************************************************
+  * @file    STM32RTC.cpp
+  * @author  WI6LABS
+  * @version V1.0.0
+  * @date    12-December-2017
+  * @brief   Provides a RTC interface for Arduino
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+#include <time.h>
+
+#include "STM32RTC.h"
+
+#define EPOCH_TIME_OFF      946684800  // This is 1st January 2000, 00:00:00 in epoch time
+#define EPOCH_TIME_YEAR_OFF 100        // years since 1900
+
+// Initialize static variable
+bool STM32RTC::_configured = false;
+
+STM32RTC::STM32RTC(void): _clockSource(RTC_LSI_CLOCK)
+{
+
+}
+
+/**
+  * @brief initializes the RTC
+  * @param resetTime: if true reconfigures the RTC
+  * @param format: hour format: HOUR_12 or HOUR_24(default)
+  * @retval None
+  */
+void STM32RTC::begin(bool resetTime, RTCHourFormats_t format)
+{
+  if(resetTime == true) {
+    _configured = false;
+  }
+  begin(format);
+}
+
+/**
+  * @brief initializes the RTC
+  * @param format: hour format: HOUR_12 or HOUR_24(default)
+  * @retval None
+  */
+void STM32RTC::begin(RTCHourFormats_t format)
+{
+  if(_configured == false) {
+    RTC_init((hourFormat_t)format, (sourceClock_t)_clockSource);
+  }
+
+  _hoursFormat = HOUR12_AM;
+  _hours = 0;
+  _minutes = 0;
+  _seconds = 0;
+  _subSeconds = 0;
+  _year = 0;
+  _month = 0;
+  _date = 0;
+  _day = 0;
+  _alarmDate = 0;
+  _alarmHours = 0;
+  _alarmMinutes = 0;
+  _alarmSeconds = 0;
+  _alarmSubSeconds = 0;
+  _alarmFormat = HOUR12_AM;
+
+  _configured = true;
+}
+
+/**
+  * @brief set the RTC clock source. By default LSI clock is selected. This
+  * method must be called before begin().
+  * @param source: clock source: RTC_LSI_CLOCK, RTC_LSE_CLOCK or RTC_HSE_CLOCK
+  * @retval None
+  */
+void STM32RTC::setClockSource(RTC_sourceClock_t source)
+{
+  if(IS_CLOCK_SOURCE(source)) {
+    _clockSource = source;
+  }
+}
+
+/**
+  * @brief enable the RTC alarm.
+  * @param match: Alarm_Match configuration
+  * @retval None
+  */
+void STM32RTC::enableAlarm(Alarm_Match match)
+{
+  Hour12_AM_PM_t format;
+  uint8_t date, hours, minutes, seconds;
+  uint32_t subSeconds;
+
+  if(_configured) {
+    RTC_GetTime(&hours, &minutes, &seconds, &subSeconds, (hourAM_PM_t*)&format);
+    date = getDay();
+
+    switch (match) {
+      case MATCH_OFF:
+        RTC_StopAlarm();
+        break;
+      case MATCH_YYMMDDHHMMSS://kept for compatibility
+      case MATCH_MMDDHHMMSS:  //kept for compatibility
+      case MATCH_DHHMMSS:
+        date = _alarmDate;
+      case MATCH_HHMMSS:
+        hours = _alarmHours;
+        format = _alarmFormat;
+      case MATCH_MMSS:
+        minutes = _alarmMinutes;
+      case MATCH_SS:
+        seconds = _alarmSeconds;
+        RTC_StartAlarm(date, hours, minutes, seconds, subSeconds, (hourAM_PM_t)format);
+        break;
+      default:
+      break;
+    }
+  }
+}
+
+/**
+  * @brief disable the RTC alarm.
+  * @retval None
+  */
+void STM32RTC::disableAlarm(void)
+{
+  if(_configured) {
+    RTC_StopAlarm();
+  }
+}
+
+/**
+  * @brief attach a callback to the RTC alarm interrupt.
+  * @param callback: pointer to the callback
+  * @retval None
+  */
+void STM32RTC::attachInterrupt(voidFuncPtr callback, void *data)
+{
+  attachAlarmCallback(callback, data);
+}
+
+/**
+  * @brief detach the RTC alarm callback.
+  * @retval None
+  */
+void STM32RTC::detachInterrupt(void)
+{
+  detachAlarmCallback();
+}
+
+// Kept for compatibility. Use STM32LowPower library.
+void STM32RTC::standbyMode(void)
+{
+
+}
+
+/*
+ * Get Functions
+ */
+
+/**
+  * @brief  get RTC subseconds.
+  * @retval return the current subseconds from the RTC.
+  */
+uint32_t STM32RTC::getSubSeconds(void)
+{
+  if(_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+  }
+  return _subSeconds;
+}
+
+/**
+  * @brief  get RTC seconds.
+  * @retval return the current seconds from the RTC.
+  */
+uint8_t STM32RTC::getSeconds(void)
+{
+  if(_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+  }
+  return _seconds;
+}
+
+/**
+  * @brief  get RTC minutes.
+  * @retval return the current minutes from the RTC.
+  */
+uint8_t STM32RTC::getMinutes(void)
+{
+  if(_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+  }
+  return _minutes;
+}
+
+/**
+  * @brief  get RTC hours.
+  * @retval return the current hours from the RTC.
+  */
+uint8_t STM32RTC::getHours(void)
+{
+  if(_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+  }
+  return _hours;
+}
+
+/**
+  * @brief  get RTC hours.
+  * @param  format: pointer to the current hour format set in the RTC: AM or PM
+  * @retval return the current hours from the RTC.
+  */
+uint8_t STM32RTC::getHours(Hour12_AM_PM_t *format)
+{
+  if(_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+
+    if(format != NULL) {
+      *format = _hoursFormat;
+    }
+  }
+  return _hours;
+}
+
+/**
+  * @brief  get RTC week day.
+  * @retval return the current week day from the RTC.
+  */
+uint8_t STM32RTC::getWeekDay(void)
+{
+  if(_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+  }
+  return _day;
+}
+
+/**
+  * @brief  get RTC date.
+  * @retval return the current date from the RTC.
+  */
+uint8_t STM32RTC::getDay(void)
+{
+  if(_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+  }
+  return _date;
+}
+
+/**
+  * @brief  get RTC month.
+  * @retval return the current month from the RTC.
+  */
+uint8_t STM32RTC::getMonth(void)
+{
+  if(_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+  }
+  return _month;
+}
+
+/**
+  * @brief  get RTC year.
+  * @retval return the current year from the RTC.
+  */
+uint8_t STM32RTC::getYear(void)
+{
+  if(_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+  }
+  return _year;
+}
+
+/**
+  * @brief  get RTC alarm subsecond.
+  * @retval return the current alarm subsecond.
+  */
+uint32_t STM32RTC::getAlarmSubSeconds(void)
+{
+  if(_configured) {
+    RTC_GetAlarm(&_alarmDate, &_alarmHours, &_alarmMinutes, &_alarmSeconds, &_alarmSubSeconds, (hourAM_PM_t*)&_alarmFormat);
+  }
+  return _alarmSubSeconds;
+}
+
+/**
+  * @brief  get RTC alarm second.
+  * @retval return the current alarm second.
+  */
+uint8_t STM32RTC::getAlarmSeconds(void)
+{
+  if(_configured) {
+    RTC_GetAlarm(&_alarmDate, &_alarmHours, &_alarmMinutes, &_alarmSeconds, &_alarmSubSeconds, (hourAM_PM_t*)&_alarmFormat);
+  }
+  return _alarmSeconds;
+}
+
+/**
+  * @brief  get RTC alarm minute.
+  * @retval return the current alarm minute.
+  */
+uint8_t STM32RTC::getAlarmMinutes(void)
+{
+  if(_configured) {
+    RTC_GetAlarm(&_alarmDate, &_alarmHours, &_alarmMinutes, &_alarmSeconds, &_alarmSubSeconds, (hourAM_PM_t*)&_alarmFormat);
+  }
+  return _alarmMinutes;
+}
+
+/**
+  * @brief  get RTC alarm hour.
+  * @retval return the current alarm hour.
+  */
+uint8_t STM32RTC::getAlarmHours(void)
+{
+  if(_configured) {
+    RTC_GetAlarm(&_alarmDate, &_alarmHours, &_alarmMinutes, &_alarmSeconds, &_alarmSubSeconds, (hourAM_PM_t*)&_alarmFormat);
+  }
+  return _alarmHours;
+}
+
+/**
+  * @brief  get RTC alarm hour.
+  * @param  format: pointer to the current hour format: AM or PM
+  * @retval return the current alarm hour.
+  */
+uint8_t STM32RTC::getAlarmHours(Hour12_AM_PM_t *format)
+{
+  if(_configured) {
+    RTC_GetAlarm(&_alarmDate, &_alarmHours, &_alarmMinutes, &_alarmSeconds, &_alarmSubSeconds, (hourAM_PM_t*)&_alarmFormat);
+
+    if(format != NULL) {
+      *format = _alarmFormat;
+    }
+  }
+  return _alarmHours;
+}
+
+/**
+  * @brief  get RTC alarm date.
+  * @retval return the current alarm date.
+  */
+uint8_t STM32RTC::getAlarmDay(void)
+{
+  if(_configured) {
+    RTC_GetAlarm(&_alarmDate, &_alarmHours, &_alarmMinutes, &_alarmSeconds, &_alarmSubSeconds, (hourAM_PM_t*)&_alarmFormat);
+  }
+  return _alarmDate;
+}
+
+/**
+  * @brief  get RTC alarm month.
+  * @NOTE   This function is kept for compatibility but the STM32 RTC
+  *         can't assign a month to an alarm. See board datasheet.
+  * @retval always returns 0
+  */
+uint8_t STM32RTC::getAlarmMonth(void)
+{
+  return 0;
+}
+
+/**
+  * @brief  get RTC alarm year.
+  * @NOTE   This function is kept for compatibility but the STM32 RTC
+  *         can't assign a year to an alarm. See board datasheet.
+  * @retval always returns 0
+  */
+uint8_t STM32RTC::getAlarmYear(void)
+{
+  return 0;
+}
+
+/*
+ * Set Functions
+ */
+
+/**
+  * @brief  set RTC subseconds.
+  * @param  subseconds: 0-999
+  * @retval none
+  */
+void STM32RTC::setSubSeconds(uint32_t subSeconds)
+{
+ if (_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+    if(subSeconds < 1000) {
+    _subSeconds = subSeconds;
+    }
+    RTC_SetTime(_hours, _minutes, _seconds, _subSeconds, (hourAM_PM_t)_hoursFormat);
+ }
+}
+
+/**
+  * @brief  set RTC seconds.
+  * @param  seconds: 0-59
+  * @retval none
+  */
+void STM32RTC::setSeconds(uint8_t seconds)
+{
+  if (_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+    if(seconds < 60) {
+      _seconds = seconds;
+    }
+    RTC_SetTime(_hours, _minutes, _seconds, _subSeconds, (hourAM_PM_t)_hoursFormat);
+  }
+}
+
+/**
+  * @brief  set RTC minutes.
+  * @param  minutes: 0-59
+  * @retval none
+  */
+void STM32RTC::setMinutes(uint8_t minutes)
+{
+  if (_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+    if(minutes < 60) {
+      _minutes = minutes;
+    }
+    RTC_SetTime(_hours, _minutes, _seconds, _subSeconds, (hourAM_PM_t)_hoursFormat);
+  }
+}
+
+/**
+  * @brief  set RTC hours.
+  * @param  hours: 0-23
+  * @retval none
+  */
+void STM32RTC::setHours(uint8_t hours)
+{
+  if (_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+    if(hours < 24) {
+      _hours = hours;
+    }
+    RTC_SetTime(_hours, _minutes, _seconds, _subSeconds, (hourAM_PM_t)_hoursFormat);
+  }
+}
+
+/**
+  * @brief  set RTC hours.
+  * @param  hours: 0-23 or 0-12
+  * @param  hours format: AM or PM
+  * @retval none
+  */
+void STM32RTC::setHours(uint8_t hours, Hour12_AM_PM_t format)
+{
+  if (_configured) {
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+    if(hours < 24) {
+      _hours = hours;
+    }
+    _hoursFormat = format;
+    RTC_SetTime(_hours, _minutes, _seconds, _subSeconds, (hourAM_PM_t)_hoursFormat);
+  }
+}
+
+/**
+  * @brief  set RTC time.
+  * @param  hours: 0-23
+  * @param  minutes: 0-59
+  * @param  seconds: 0-59
+  * @retval none
+  */
+void STM32RTC::setTime(uint8_t hours, uint8_t minutes, uint8_t seconds)
+{
+  if (_configured) {
+    setSeconds(seconds);
+    setMinutes(minutes);
+    setHours(hours);
+  }
+}
+
+/**
+  * @brief  set RTC time.
+  * @param  hours: 0-23 or 0-12
+  * @param  minutes: 0-59
+  * @param  seconds: 0-59
+  * @param  hour format: AM or PM
+  * @retval none
+  */
+void STM32RTC::setTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, Hour12_AM_PM_t format)
+{
+  if (_configured) {
+    setSubSeconds(subSeconds);
+    setSeconds(seconds);
+    setMinutes(minutes);
+    setHours(hours, format);
+  }
+}
+
+/**
+  * @brief  set RTC week day.
+  * @param  week day: 1-7 (Monday first)
+  * @retval none
+  */
+void STM32RTC::setWeekDay(uint8_t weekDay)
+{
+  if (_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+    if((weekDay >= 1) && (weekDay <= 7)) {
+      _day = weekDay;
+    }
+    RTC_SetDate(_year, _month, _date, _day);
+  }
+}
+
+/**
+  * @brief  set RTC date.
+  * @param  date: 1-31
+  * @retval none
+  */
+void STM32RTC::setDay(uint8_t day)
+{
+  if (_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+    if((day >= 1) && (day <= 31)) {
+      _date = day;
+    }
+    RTC_SetDate(_year, _month, _date, _day);
+  }
+}
+
+/**
+  * @brief  set RTC month.
+  * @param  month: 1-12
+  * @retval none
+  */
+void STM32RTC::setMonth(uint8_t month)
+{
+  if (_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+    if((month >= 1) && (month <= 12)) {
+      _month = month;
+    }
+    RTC_SetDate(_year, _month, _date, _day);
+  }
+}
+
+/**
+  * @brief  set RTC year.
+  * @param  year: 0-99
+  * @retval none
+  */
+void STM32RTC::setYear(uint8_t year)
+{
+  if (_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+    if(year < 100) {
+      _year = year;
+    }
+    RTC_SetDate(_year, _month, _date, _day);
+  }
+}
+
+/**
+  * @brief  set RTC calendar.
+  * @param  day: 1-31
+  * @param  month: 1-12
+  * @param  year: 0-99
+  * @retval none
+  */
+void STM32RTC::setDate(uint8_t day, uint8_t month, uint8_t year)
+{
+  if (_configured) {
+    setDay(day);
+    setMonth(month);
+    setYear(year);
+  }
+}
+
+/**
+  * @brief  set RTC calendar.
+  * @param  weekDay: 1-7 (Monday first)
+  * @param  day: 1-31
+  * @param  month: 1-12
+  * @param  year: 0-99
+  * @retval none
+  */
+void STM32RTC::setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year)
+{
+  if (_configured) {
+    setWeekDay(weekDay);
+    setDay(day);
+    setMonth(month);
+    setYear(year);
+  }
+}
+
+/**
+  * @brief  set RTC alarm second.
+  * @param  seconds: 0-59
+  * @retval none
+  */
+void STM32RTC::setAlarmSeconds(uint8_t seconds)
+{
+  if (_configured) {
+    if(seconds < 60) {
+      _alarmSeconds = seconds;
+    }
+  }
+}
+
+/**
+  * @brief  set RTC alarm minute.
+  * @param  minutes: 0-59
+  * @retval none
+  */
+void STM32RTC::setAlarmMinutes(uint8_t minutes)
+{
+  if (_configured) {
+    if(minutes < 60) {
+      _alarmMinutes = minutes;
+    }
+  }
+}
+
+/**
+  * @brief  set RTC alarm hour.
+  * @param  hour: 0-23
+  * @retval none
+  */
+void STM32RTC::setAlarmHours(uint8_t hours)
+{
+  if (_configured) {
+    if(hours < 24) {
+      _alarmHours = hours;
+    }
+  }
+}
+
+/**
+  * @brief  set RTC alarm hour.
+  * @param  hour: 0-23 or 0-12
+  * @param  hour format: AM or PM
+  * @retval none
+  */
+void STM32RTC::setAlarmHours(uint8_t hours, Hour12_AM_PM_t format)
+{
+  if (_configured) {
+    if(hours < 24) {
+      _alarmHours = hours;
+    }
+    _alarmFormat = format;
+  }
+}
+
+/**
+  * @brief  set RTC alarm time.
+  * @param  hours: 0-23
+  * @param  minutes: 0-59
+  * @param  seconds: 0-59
+  * @retval none
+  */
+void STM32RTC::setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds)
+{
+  if (_configured) {
+    setAlarmHours(hours);
+    setAlarmMinutes(minutes);
+    setAlarmSeconds(seconds);
+  }
+}
+
+/**
+  * @brief  set RTC alarm time.
+  * @param  hours: 0-23
+  * @param  minutes: 0-59
+  * @param  seconds: 0-59
+  * @param  hour format: AM or PM
+  * @retval none
+  */
+void STM32RTC::setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, Hour12_AM_PM_t format)
+{
+  if (_configured) {
+    setAlarmHours(hours, format);
+    setAlarmMinutes(minutes);
+    setAlarmSeconds(seconds);
+  }
+}
+
+/**
+  * @brief  set RTC alarm date.
+  * @param  day: 1-31
+  * @retval none
+  */
+void STM32RTC::setAlarmDay(uint8_t day)
+{
+  if (_configured) {
+    if((day >= 1) && (day <= 31)) {
+      _alarmDate = day;
+    }
+  }
+}
+
+/**
+  * @brief  set RTC alarm month.
+  * @NOTE   This function is kept for compatibility but the STM32 RTC
+  *         can't assign a month to an alarm. See board datasheet.
+  * @param  month is ignored.
+  */
+void STM32RTC::setAlarmMonth(uint8_t month)
+{
+  UNUSED(month);
+}
+
+/**
+  * @brief  set RTC alarm year.
+  * @NOTE   This function is kept for compatibility but the STM32 RTC
+  *         can't assign a year to an alarm. See board datasheet.
+  * @param  year is ignored.
+  */
+void STM32RTC::setAlarmYear(uint8_t year)
+{
+  UNUSED(year);
+}
+
+/**
+  * @brief  set RTC alarm date.
+  * @NOTE   Parameters month and year are ingored because the STM32 RTC can't
+  *         assign a month or year to an alarm. See board datasheet.
+  * @param  day: 1-31
+  * @param  month is ignored
+  * @param  year is ignored
+  */
+void STM32RTC::setAlarmDate(uint8_t day, uint8_t month, uint8_t year)
+{
+  UNUSED(month);
+  UNUSED(year);
+
+  setAlarmDay(day);
+}
+
+/**
+  * @brief  get epoch time
+  * @retval epoch time in seconds
+  */
+uint32_t STM32RTC::getEpoch(void)
+{
+  struct tm tm;
+
+  if(_configured) {
+    RTC_GetDate(&_year, &_month, &_date, &_day);
+    RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, (hourAM_PM_t*)&_hoursFormat);
+  }
+
+  tm.tm_isdst = -1;
+  tm.tm_yday = 0;
+  tm.tm_wday = _day - 1;
+  tm.tm_year = _year + EPOCH_TIME_YEAR_OFF;
+  tm.tm_mon = _month - 1;
+  tm.tm_mday = _date;
+  tm.tm_hour = _hours;
+  tm.tm_min = _minutes;
+  tm.tm_sec = _seconds;
+
+  return mktime(&tm);
+}
+
+/**
+  * @brief  get epoch time since 1st January 2000, 00:00:00
+  * @retval epoch time in seconds
+  */
+uint32_t STM32RTC::getY2kEpoch(void)
+{
+  return (getEpoch() - EPOCH_TIME_OFF);
+}
+
+/**
+  * @brief  set RTC alarm from epoch time
+  * @param  epoch time in seconds
+  */
+void STM32RTC::setAlarmEpoch(uint32_t ts)
+{
+  if (_configured) {
+    if (ts < EPOCH_TIME_OFF) {
+      ts = EPOCH_TIME_OFF;
+    }
+
+    time_t t = ts;
+    struct tm* tmp = gmtime(&t);
+
+    setAlarmDay(tmp->tm_mday);
+    setAlarmHours(tmp->tm_hour);
+    setAlarmMinutes(tmp->tm_min);
+    setAlarmSeconds(tmp->tm_sec);
+    enableAlarm(MATCH_DHHMMSS);
+  }
+}
+
+/**
+  * @brief  set RTC time from epoch time
+  * @param  epoch time in seconds
+  */
+void STM32RTC::setEpoch(uint32_t ts)
+{
+  if (_configured) {
+    if (ts < EPOCH_TIME_OFF) {
+      ts = EPOCH_TIME_OFF;
+    }
+
+    time_t t = ts;
+    struct tm* tmp = gmtime(&t);
+
+    _year = tmp->tm_year - EPOCH_TIME_YEAR_OFF;
+    _month = tmp->tm_mon + 1;
+    _date = tmp->tm_mday;
+    _day = tmp->tm_wday + 1;
+    _hours = tmp->tm_hour;
+    _minutes = tmp->tm_min;
+    _seconds = tmp->tm_sec;
+
+    RTC_SetDate(_year, _month, _date, _day);
+    RTC_SetTime(_hours, _minutes, _seconds, _subSeconds, (hourAM_PM_t)_hoursFormat);
+  }
+}
+
+/**
+  * @brief  set RTC time from epoch time since 1st January 2000, 00:00:00
+  * @param  epoch time in seconds
+  */
+void STM32RTC::setY2kEpoch(uint32_t ts)
+{
+  if (_configured) {
+    setEpoch(ts + EPOCH_TIME_OFF);
+  }
+}

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -1,0 +1,197 @@
+/**
+  ******************************************************************************
+  * @file    STM32RTC.h
+  * @author  WI6LABS
+  * @version V1.0.0
+  * @date    12-December-2017
+  * @brief   Provides a RTC interface for Arduino
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+#ifndef __STM32_RTC_H
+#define __STM32_RTC_H
+
+#include "Arduino.h"
+
+// Check if RTC HAL enable in variants/board_name/stm32yzxx_hal_conf.h
+#ifndef HAL_RTC_MODULE_ENABLED
+#error "RTC configuration is missing. Check flag HAL_RTC_MODULE_ENABLED in variants/board_name/stm32yzxx_hal_conf.h"
+#endif
+
+typedef void(*voidFuncPtr)(void *);
+
+// Hour format: 12 or 24 hours
+typedef enum {
+  HOUR_12,
+  HOUR_24
+} RTCHourFormats_t;
+
+//Time AM/PM definition
+typedef enum {
+  HOUR12_AM,
+  HOUR12_PM
+} Hour12_AM_PM_t;
+
+// Clock source selection
+typedef enum {
+  RTC_LSI_CLOCK,
+  RTC_LSE_CLOCK,
+  RTC_HSE_CLOCK
+} RTC_sourceClock_t;
+
+#define IS_CLOCK_SOURCE(SRC) (((SRC) == RTC_LSI_CLOCK) || ((SRC) == RTC_LSE_CLOCK) ||\
+                              ((SRC) == RTC_HSE_CLOCK))
+
+class STM32RTC {
+public:
+
+  enum Alarm_Match: uint8_t
+  {
+    MATCH_OFF          = 0, // Never
+    MATCH_SS           = 1, // Every Minute
+    MATCH_MMSS         = 2, // Every Hour
+    MATCH_HHMMSS       = 3, // Every Day
+    MATCH_DHHMMSS      = 4, // Every Month
+
+    /* NOTE: STM32 RTC can't assign a month or a year to an alarm. Those enum
+    are kept for compatibility but are ignored inside enableAlarm(). */
+    MATCH_MMDDHHMMSS   = 5,
+    MATCH_YYMMDDHHMMSS = 6
+  };
+
+  STM32RTC();
+
+  void begin(bool resetTime, RTCHourFormats_t format = HOUR_24);
+  void begin(RTCHourFormats_t format = HOUR_24);
+
+  void setClockSource(RTC_sourceClock_t source);
+
+  void enableAlarm(Alarm_Match match);
+  void disableAlarm(void);
+
+  void attachInterrupt(voidFuncPtr callback, void *data = NULL);
+  void detachInterrupt(void);
+
+  // Kept for compatibility: use STM32LowPower library.
+  void standbyMode();
+
+  /* Get Functions */
+
+  uint32_t getSubSeconds(void);
+  uint8_t getSeconds(void);
+  uint8_t getMinutes(void);
+  uint8_t getHours(void);
+  uint8_t getHours(Hour12_AM_PM_t *format);
+
+  uint8_t getWeekDay(void);
+  uint8_t getDay(void);
+  uint8_t getMonth(void);
+  uint8_t getYear(void);
+
+  uint32_t getAlarmSubSeconds(void);
+  uint8_t getAlarmSeconds(void);
+  uint8_t getAlarmMinutes(void);
+  uint8_t getAlarmHours(void);
+  uint8_t getAlarmHours(Hour12_AM_PM_t *format);
+
+  uint8_t getAlarmDay(void);
+
+  // Kept for compatibility with Arduino RTCZero library.
+  uint8_t getAlarmMonth();
+  uint8_t getAlarmYear();
+
+  /* Set Functions */
+
+  void setSubSeconds(uint32_t subSeconds);
+  void setSeconds(uint8_t seconds);
+  void setMinutes(uint8_t minutes);
+  void setHours(uint8_t hours);
+  void setHours(uint8_t hours, Hour12_AM_PM_t format);
+  void setTime(uint8_t hours, uint8_t minutes, uint8_t seconds);
+  void setTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, Hour12_AM_PM_t format);
+
+  void setWeekDay(uint8_t weekDay);
+  void setDay(uint8_t day);
+  void setMonth(uint8_t month);
+  void setYear(uint8_t year);
+  void setDate(uint8_t day, uint8_t month, uint8_t year);
+  void setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year);
+
+  void setAlarmSeconds(uint8_t seconds);
+  void setAlarmMinutes(uint8_t minutes);
+  void setAlarmHours(uint8_t hours);
+  void setAlarmHours(uint8_t hours, Hour12_AM_PM_t format);
+  void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds);
+  void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, Hour12_AM_PM_t format);
+
+  void setAlarmDay(uint8_t day);
+
+  // Kept for compatibility with Arduino RTCZero library.
+  void setAlarmMonth(uint8_t month);
+  void setAlarmYear(uint8_t year);
+  void setAlarmDate(uint8_t day, uint8_t month, uint8_t year);
+
+  /* Epoch Functions */
+
+  uint32_t getEpoch(void);
+  uint32_t getY2kEpoch(void);
+  void setEpoch(uint32_t ts);
+  void setY2kEpoch(uint32_t ts);
+  void setAlarmEpoch(uint32_t ts);
+
+  bool isConfigured(void) {
+    return _configured;
+  }
+
+private:
+  static bool _configured;
+
+  Hour12_AM_PM_t _hoursFormat;
+  uint8_t     _hours;
+  uint8_t     _minutes;
+  uint8_t     _seconds;
+  uint32_t    _subSeconds;
+  uint8_t     _year;
+  uint8_t     _month;
+  uint8_t     _date;
+  uint8_t     _day;
+
+  uint8_t     _alarmDate;
+  uint8_t     _alarmHours;
+  uint8_t     _alarmMinutes;
+  uint8_t     _alarmSeconds;
+  uint32_t    _alarmSubSeconds;
+  Hour12_AM_PM_t _alarmFormat;
+
+  RTC_sourceClock_t _clockSource;
+};
+
+#endif // __STM32_RTC_H


### PR DESCRIPTION
Source files of the RTC library.

This library is based on the RTCZero library. 
We tried to keep the compatibility as far as possible.

Tested on NUCLEO-L476RG and NUCLEO-L053R8.
Compilation test OK on all variant boards.

Requires the validation of this [PR](https://github.com/stm32duino/Arduino_Core_STM32/pull/177).