### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,67 +12,67 @@ STM32RTC	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getInstance		KEYWORD2
+getInstance	KEYWORD2
 
-getWeekDay		KEYWORD2
-getDay			KEYWORD2
-getMonth		KEYWORD2
-getYear			KEYWORD2
-getHours		KEYWORD2
-getMinutes		KEYWORD2
-getSeconds 		KEYWORD2
-getSubSeconds		KEYWORD2
-getTime		KEYWORD2
-getDate		KEYWORD2
+getWeekDay	KEYWORD2
+getDay	KEYWORD2
+getMonth	KEYWORD2
+getYear	KEYWORD2
+getHours	KEYWORD2
+getMinutes	KEYWORD2
+getSeconds	KEYWORD2
+getSubSeconds	KEYWORD2
+getTime	KEYWORD2
+getDate	KEYWORD2
 
-setWeekDay		KEYWORD2
-setDay			KEYWORD2
-setMonth		KEYWORD2
-setYear			KEYWORD2
-setHours 		KEYWORD2
-setMinutes		KEYWORD2
-setSeconds 		KEYWORD2
-setSubSeconds		KEYWORD2
-setDate			KEYWORD2
-setTime			KEYWORD2
+setWeekDay	KEYWORD2
+setDay	KEYWORD2
+setMonth	KEYWORD2
+setYear	KEYWORD2
+setHours	KEYWORD2
+setMinutes	KEYWORD2
+setSeconds	KEYWORD2
+setSubSeconds	KEYWORD2
+setDate	KEYWORD2
+setTime	KEYWORD2
 
-getEpoch		KEYWORD2
-getY2kEpoch		KEYWORD2
-setEpoch		KEYWORD2
-setY2kEpoch		KEYWORD2
-setAlarmEpoch		KEYWORD2
+getEpoch	KEYWORD2
+getY2kEpoch	KEYWORD2
+setEpoch	KEYWORD2
+setY2kEpoch	KEYWORD2
+setAlarmEpoch	KEYWORD2
 
-getAlarmDay		KEYWORD2
-getAlarmHours 		KEYWORD2
-getAlarmMinutes		KEYWORD2
-getAlarmSeconds 	KEYWORD2
+getAlarmDay	KEYWORD2
+getAlarmHours 	KEYWORD2
+getAlarmMinutes	KEYWORD2
+getAlarmSeconds	KEYWORD2
 getAlarmSubSeconds	KEYWORD2
 
-setAlarmSeconds		KEYWORD2
-setAlarmMinutes		KEYWORD2
-setAlarmHours		KEYWORD2
-setAlarmHours		KEYWORD2
-setAlarmTime		KEYWORD2
-setAlarmTime		KEYWORD2
-setAlarmDay		KEYWORD2
-setAlarmMonth		KEYWORD2
-setAlarmYear		KEYWORD2
-setAlarmDate		KEYWORD2
+setAlarmSeconds	KEYWORD2
+setAlarmMinutes	KEYWORD2
+setAlarmHours	KEYWORD2
+setAlarmHours	KEYWORD2
+setAlarmTime	KEYWORD2
+setAlarmTime	KEYWORD2
+setAlarmDay	KEYWORD2
+setAlarmMonth	KEYWORD2
+setAlarmYear	KEYWORD2
+setAlarmDate	KEYWORD2
 
-enableAlarm 		KEYWORD2
-disableAlarm 		KEYWORD2
+enableAlarm 	KEYWORD2
+disableAlarm 	KEYWORD2
 
-attachInterrupt		KEYWORD2
-detachInterrupt		KEYWORD2
+attachInterrupt	KEYWORD2
+detachInterrupt	KEYWORD2
 
-getClockSource		KEYWORD2
-setClockSource		KEYWORD2
+getClockSource	KEYWORD2
+setClockSource	KEYWORD2
 isConfigured	KEYWORD2
 
 getPrediv	KEYWORD2
 setPrediv	KEYWORD2
 
-IS_CLOCK_SOURCE		KEYWORD2
+IS_CLOCK_SOURCE	KEYWORD2
 IS_HOUR_FORMAT	KEYWORD2
 
 #######################################
@@ -85,8 +85,8 @@ MATCH_HHMMSS	LITERAL1
 MATCH_DHHMMSS	LITERAL1
 MATCH_MMDDHHMMSS	LITERAL1
 MATCH_YYMMDDHHMMSS	LITERAL1
-RTC_HOUR_12		LITERAL1
-RTC_HOUR_24		LITERAL1
+RTC_HOUR_12	LITERAL1
+RTC_HOUR_24	LITERAL1
 RTC_AM	LITERAL1
 RTC_PM	LITERAL1
 RTC_LSE_CLOCK	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords