### PR TITLE
Using external 32k768 crystal as default clock source instead of the …

### DIFF
--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -188,7 +188,7 @@ public:
   friend class STM32LowPower;
 
 private:
-  STM32RTC(void): _clockSource(RTC_LSI_CLOCK) {}
+  STM32RTC(void): _clockSource(RTC_LSE_CLOCK) {}
 
   static bool _configured;
 


### PR DESCRIPTION
…inaccurate internal RC oscillator.

Signed-off-by: Christoph Tack <prog.send@gmail.com>