### PR TITLE
Handle reset time

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ _Time and date configuration (added for convenience)_
 * **`void getTime(uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *subSeconds, AM_PM *period = NULL)`**
 * **`void getDate(uint8_t *weekDay, uint8_t *day, uint8_t *month, uint8_t *year)`**
 
+### Since STM32 Core version > 1.5.0
+_Reset time management_
+By default, if a time is set it will not be reset afer a reboot.
+
+Using `begin(true)` or `begin(true, HOUR_24)` will reset the RTC registers.
+
+To know if a time has already been set use:
+* **`bool isTimeSet(void)`**
+```
+  if (!rtc.isTimeSet()) {
+    // Set the time
+    rtc.setHours(hours);
+    rtc.setMinutes(minutes);
+    rtc.setSeconds(seconds);
+  }
+```
+
 Refer to the Arduino RTC documentation for the other functions  
 http://arduino.cc/en/Reference/RTC
 

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -45,6 +45,7 @@
 
 // Initialize static variable
 bool STM32RTC::_configured = false;
+bool STM32RTC::_reset = false;
 
 /**
   * @brief initializes the RTC
@@ -54,6 +55,7 @@ bool STM32RTC::_configured = false;
   */
 void STM32RTC::begin(bool resetTime, Hour_Format format)
 {
+  _reset = resetTime;
   if(resetTime == true) {
     _configured = false;
     _alarmEnabled = false;
@@ -71,7 +73,11 @@ void STM32RTC::begin(Hour_Format format)
   if(_configured == false) {
     RTC_init((format == HOUR_12)? HOUR_FORMAT_12: HOUR_FORMAT_24,
              (_clockSource == LSE_CLOCK)? ::LSE_CLOCK:
-             (_clockSource == HSE_CLOCK)? ::HSE_CLOCK : ::LSI_CLOCK);
+             (_clockSource == HSE_CLOCK)? ::HSE_CLOCK : ::LSI_CLOCK
+#if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01050000)
+              , _reset
+#endif
+             );
     // Must be set before call of sync methods
     _configured = true;
     syncTime();

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -185,12 +185,21 @@ public:
   bool isAlarmEnabled(void) {
     return _alarmEnabled;
   }
+  bool isTimeSet(void) {
+#if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01050000)
+    return RTC_IsTimeSet();
+#else
+    return false;
+#endif
+  }
+
   friend class STM32LowPower;
 
 private:
   STM32RTC(void): _clockSource(LSI_CLOCK) {}
 
   static bool _configured;
+  static bool _reset;
 
   AM_PM   _hoursPeriod;
   uint8_t     _hours;


### PR DESCRIPTION
Require STM32 core version higher than 1.5.0.

Fix #11 

Require https://github.com/stm32duino/Arduino_Core_STM32/pull/442 to be functional.

This PR do not break backward compatibilities with old core version as new core version API is used to hadnle this.