### PR TITLE
Remove usage of log2() with floating point value

### DIFF
--- a/src/rtc.c
+++ b/src/rtc.c
@@ -35,7 +35,6 @@
   */
 
 #include "rtc.h"
-#include <math.h>
 
 #if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01090000) &&\
     defined(HAL_RTC_MODULE_ENABLED) && !defined(HAL_RTC_MODULE_ONLY)
@@ -76,6 +75,11 @@ static void RTC_initClock(sourceClock_t source);
 #if !defined(STM32F1xx)
 static void RTC_computePrediv(int8_t *asynch, int16_t *synch);
 #endif /* !STM32F1xx */
+
+static inline int _log2(int x)
+{
+  return (x > 0) ? (sizeof(int) * 8 - __builtin_clz(x) - 1) : 0;
+}
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -217,7 +221,7 @@ void RTC_setPrediv(int8_t asynch, int16_t synch)
   } else {
     RTC_computePrediv(&predivAsync, &predivSync);
   }
-  predivSync_bits = (uint8_t)log2(predivSync) + 1;
+  predivSync_bits = (uint8_t)_log2(predivSync) + 1;
 #else
   UNUSED(asynch);
   UNUSED(synch);
@@ -241,7 +245,7 @@ void RTC_getPrediv(int8_t *asynch, int16_t *synch)
     *asynch = predivAsync;
     *synch = predivSync;
   }
-  predivSync_bits = (uint8_t)log2(predivSync) + 1;
+  predivSync_bits = (uint8_t)_log2(predivSync) + 1;
 #else
   UNUSED(asynch);
   UNUSED(synch);


### PR DESCRIPTION
This allows to save space. (around 4k).
Thanks to @PeeJay in this comment:
https://github.com/stm32duino/STM32LowPower/issues/13#issuecomment-689512983

Note that I've added a check to 0 value because `__builtin_clz ` with 0 produce an undefined result:
https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html

> 
> Built-in Function: int **__builtin_clz** (unsigned int x)
> 
>     Returns the number of leading 0-bits in x, starting at the most significant bit position. If x is 0, the result is undefined. 
> 


