### PR TITLE
[Enhancement] Add date retention functionality for STM32F1xx based boards

### DIFF
--- a/src/rtc.c
+++ b/src/rtc.c
@@ -363,7 +363,7 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
     RtcHandle.DateToUpdate.Year  = BackupDate.Year;
     RtcHandle.DateToUpdate.Month = BackupDate.Month;
     RtcHandle.DateToUpdate.Date  = BackupDate.Date;
-    // Check for valid weekday separately so that if there is a problem we have still atleast set the date
+    // Check for valid weekday separately so that if there is a problem we have still at least set the date
     if (IS_RTC_WEEKDAY(BackupDate.WeekDay)) {
       RtcHandle.DateToUpdate.WeekDay = BackupDate.WeekDay;
     }

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -516,7 +516,9 @@ void RTC_SetDate(uint8_t year, uint8_t month, uint8_t day, uint8_t wday)
     RTC_DateStruct.WeekDay = wday;
     HAL_RTC_SetDate(&RtcHandle, &RTC_DateStruct, RTC_FORMAT_BIN);
     setBackupRegister(RTC_BKP_INDEX, RTC_BKP_VALUE);
+#if defined(STM32F1xx)
     RTC_StoreDate();
+#endif
   }
 }
 

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -363,6 +363,7 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
     RtcHandle.DateToUpdate.Year  = BackupDate.Year;
     RtcHandle.DateToUpdate.Month = BackupDate.Month;
     RtcHandle.DateToUpdate.Date  = BackupDate.Date;
+    RtcHandle.DateToUpdate.WeekDay  = BackupDate.WeekDay;
     /* Read the time so that the date is rolled over if required */
     HAL_RTC_GetTime(&RtcHandle, &DummyTime, RTC_FORMAT_BIN);
     /* Store the date or it will revert again if we lose power before manually updating. */

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -363,7 +363,10 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
     RtcHandle.DateToUpdate.Year  = BackupDate.Year;
     RtcHandle.DateToUpdate.Month = BackupDate.Month;
     RtcHandle.DateToUpdate.Date  = BackupDate.Date;
-    RtcHandle.DateToUpdate.WeekDay  = BackupDate.WeekDay;
+    // Check for valid weekday separately so that if there is a problem we have still atleast set the date
+    if (IS_RTC_WEEKDAY(BackupDate.WeekDay)) {
+      RtcHandle.DateToUpdate.WeekDay = BackupDate.WeekDay;
+    }
     /* Read the time so that the date is rolled over if required */
     HAL_RTC_GetTime(&RtcHandle, &DummyTime, RTC_FORMAT_BIN);
     /* Store the date or it will revert again if we lose power before manually updating. */

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -355,8 +355,8 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
   RTC_DateTypeDef BackupDate;
   RTC_TimeTypeDef DummyTime;
   uint32_t dateMem;
-  dateMem = HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_DR3);
-  dateMem |= HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_DR2) << 16;
+  dateMem = HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_SAVE_THE_DATE+1);
+  dateMem |= HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_SAVE_THE_DATE) << 16;
   memcpy(&BackupDate, &dateMem, sizeof(uint32_t));
   if (IS_RTC_YEAR(BackupDate.Year) && IS_RTC_MONTH(BackupDate.Month) && IS_RTC_DATE(BackupDate.Date)) {
     /* Change the date retrieved from the backup registers */
@@ -756,8 +756,8 @@ void RTC_StoreDate(void)
   /* Store the date in the backup registers */
   uint32_t dateToStore;
   memcpy(&dateToStore, &RtcHandle.DateToUpdate, 4);
-  HAL_RTCEx_BKUPWrite(&RtcHandle, RTC_BKP_DR2, dateToStore >> 16);
-  HAL_RTCEx_BKUPWrite(&RtcHandle, RTC_BKP_DR3, dateToStore & 0xffff);
+  HAL_RTCEx_BKUPWrite(&RtcHandle, RTC_BKP_SAVE_THE_DATE, dateToStore >> 16);
+  HAL_RTCEx_BKUPWrite(&RtcHandle, RTC_BKP_SAVE_THE_DATE+1, dateToStore & 0xffff);
 }
 #endif
 

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -363,9 +363,13 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
     RtcHandle.DateToUpdate.Year  = BackupDate.Year;
     RtcHandle.DateToUpdate.Month = BackupDate.Month;
     RtcHandle.DateToUpdate.Date  = BackupDate.Date;
-
     /* Read the time so that the date is rolled over if required */
     HAL_RTC_GetTime(&RtcHandle, &DummyTime, RTC_FORMAT_BIN);
+    /* Store the date or it will revert again if we lose power before manually updating. */
+    if (BackupDate.Date != RtcHandle.DateToUpdate.Date)
+    {
+      RTC_StoreDate();
+    }
   }
 #endif
 

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -34,6 +34,7 @@
   ******************************************************************************
   */
 #include "rtc.h"
+#include <string.h>
 
 #if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01090000) &&\
     defined(HAL_RTC_MODULE_ENABLED) && !defined(HAL_RTC_MODULE_ONLY)

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -355,7 +355,7 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
   RTC_DateTypeDef BackupDate;
   RTC_TimeTypeDef DummyTime;
   uint32_t dateMem;
-  dateMem = HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_SAVE_THE_DATE+1);
+  dateMem = HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_SAVE_THE_DATE + 1);
   dateMem |= HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_SAVE_THE_DATE) << 16;
   memcpy(&BackupDate, &dateMem, sizeof(uint32_t));
   if (IS_RTC_YEAR(BackupDate.Year) && IS_RTC_MONTH(BackupDate.Month) && IS_RTC_DATE(BackupDate.Date)) {
@@ -757,7 +757,7 @@ void RTC_StoreDate(void)
   uint32_t dateToStore;
   memcpy(&dateToStore, &RtcHandle.DateToUpdate, 4);
   HAL_RTCEx_BKUPWrite(&RtcHandle, RTC_BKP_SAVE_THE_DATE, dateToStore >> 16);
-  HAL_RTCEx_BKUPWrite(&RtcHandle, RTC_BKP_SAVE_THE_DATE+1, dateToStore & 0xffff);
+  HAL_RTCEx_BKUPWrite(&RtcHandle, RTC_BKP_SAVE_THE_DATE + 1, dateToStore & 0xffff);
 }
 #endif
 

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -366,8 +366,7 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
     /* Read the time so that the date is rolled over if required */
     HAL_RTC_GetTime(&RtcHandle, &DummyTime, RTC_FORMAT_BIN);
     /* Store the date or it will revert again if we lose power before manually updating. */
-    if (BackupDate.Date != RtcHandle.DateToUpdate.Date)
-    {
+    if (BackupDate.Date != RtcHandle.DateToUpdate.Date) {
       RTC_StoreDate();
     }
   }

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -376,7 +376,7 @@ void RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
 
   HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
   HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
-  
+
 }
 
 /**

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -37,6 +37,8 @@
 #ifndef __RTC_H
 #define __RTC_H
 
+#define RTC_BKP_SAVE_THE_DATE RTC_BKP_DR3
+
 /* Includes ------------------------------------------------------------------*/
 #include <stdbool.h>
 #include "stm32_def.h"

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -165,6 +165,10 @@ void RTC_GetAlarm(uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *secon
 void attachAlarmCallback(voidCallbackPtr func, void *data);
 void detachAlarmCallback(void);
 
+#if defined(STM32F1xx)
+void RTC_StoreDate(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -37,7 +37,7 @@
 #ifndef __RTC_H
 #define __RTC_H
 
-#define RTC_BKP_SAVE_THE_DATE RTC_BKP_DR3
+#define RTC_BKP_SAVE_THE_DATE RTC_BKP_DR2
 
 /* Includes ------------------------------------------------------------------*/
 #include <stdbool.h>


### PR DESCRIPTION
**Adds date retention through power cycles on stm32f1xx based boards**

On these chips, the date details are only stored in SRAM while running, because of this, dates are not being retained after a power off even with VBAT connected.

This is fixed by using backup registers DR2 and DR3 to store the date data each time it is updated. Doing this means that the date can then be extracted and set correctly when the RTC is next initialized.