### PR TITLE
[Enhancement] Implement RTC Seconds Interrupt for STM32F1xx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.vscode/arduino.json
+.vscode/c_cpp_properties.json

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -220,7 +220,7 @@ void STM32RTC::detachInterrupt(void)
   detachAlarmCallback();
 }
 
-#if defined(STM32F1xx)
+#if defined(STM32F1xx) && defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01090000)
 /**
   * @brief attach a callback to the RTC Seconds interrupt.
   * @param callback: pointer to the callback

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -220,7 +220,7 @@ void STM32RTC::detachInterrupt(void)
   detachAlarmCallback();
 }
 
-
+#if defined(STM32F1xx)
 /**
   * @brief attach a callback to the RTC Seconds interrupt.
   * @param callback: pointer to the callback
@@ -239,6 +239,7 @@ void STM32RTC::detachSecondsInterrupt(void)
 {
   detachSecondsIrqCallback();
 }
+#endif
 
 // Kept for compatibility. Use STM32LowPower library.
 void STM32RTC::standbyMode(void)

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -220,6 +220,26 @@ void STM32RTC::detachInterrupt(void)
   detachAlarmCallback();
 }
 
+
+/**
+  * @brief attach a callback to the RTC Seconds interrupt.
+  * @param callback: pointer to the callback
+  * @retval None
+  */
+void STM32RTC::attachSecondsInterrupt(voidFuncPtr callback)
+{
+  attachSecondsIrqCallback(callback);
+}
+
+/**
+  * @brief detach the RTC Seconds callback.
+  * @retval None
+  */
+void STM32RTC::detachSecondsInterrupt(void)
+{
+  detachSecondsIrqCallback();
+}
+
 // Kept for compatibility. Use STM32LowPower library.
 void STM32RTC::standbyMode(void)
 {

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -125,7 +125,7 @@ class STM32RTC {
     void attachInterrupt(voidFuncPtr callback, void *data = nullptr);
     void detachInterrupt(void);
 
-#if defined(STM32F1xx)
+#if defined(STM32F1xx) && defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01090000)
     void attachSecondsInterrupt(voidFuncPtr callback);
     void detachSecondsInterrupt(void);
 #endif

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -124,9 +124,11 @@ class STM32RTC {
 
     void attachInterrupt(voidFuncPtr callback, void *data = nullptr);
     void detachInterrupt(void);
-    
+
+#if defined(STM32F1xx)
     void attachSecondsInterrupt(voidFuncPtr callback);
     void detachSecondsInterrupt(void);
+#endif
 
     // Kept for compatibility: use STM32LowPower library.
     void standbyMode();

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -124,6 +124,9 @@ class STM32RTC {
 
     void attachInterrupt(voidFuncPtr callback, void *data = nullptr);
     void detachInterrupt(void);
+    
+    void attachSecondsInterrupt(voidFuncPtr callback);
+    void detachSecondsInterrupt(void);
 
     // Kept for compatibility: use STM32LowPower library.
     void standbyMode();

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -732,7 +732,7 @@ void attachSecondsIrqCallback(voidCallbackPtr func)
   //LL_RTC_DisableWriteProtection(RTC);
 
   /* Setting the Wakeup time to 1 s
-       If LL_RTC_WAKEUPCLOCK_CKSPRE is selected, the frequency is 1Hz, 
+       If LL_RTC_WAKEUPCLOCK_CKSPRE is selected, the frequency is 1Hz,
        this allows to get a wakeup time equal to 1 s if the counter is 0x0 */
   //LL_RTC_WAKEUP_SetAutoReload(RTC, 0);
   //LL_RTC_WAKEUP_SetClock(RTC, LL_RTC_WAKEUPCLOCK_CKSPRE);

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -729,28 +729,26 @@ void attachSecondsIrqCallback(voidCallbackPtr func)
   /* All other variants don't have a Seconds interrupt, we will make use of the Periodic Wake Up Timer */
   /* Disable writeprotection so we can setup the periodic wakeup timer */
   //__HAL_RTC_WRITEPROTECTION_DISABLE(&RtcHandle);
-  LL_RTC_DisableWriteProtection(RTC);
-#endif /* USE_TIMEOUT */
-  }
-  
+  //LL_RTC_DisableWriteProtection(RTC);
+
   /* Setting the Wakeup time to 1 s
        If LL_RTC_WAKEUPCLOCK_CKSPRE is selected, the frequency is 1Hz, 
        this allows to get a wakeup time equal to 1 s if the counter is 0x0 */
-  LL_RTC_WAKEUP_SetAutoReload(RTC, 0);
-  LL_RTC_WAKEUP_SetClock(RTC, LL_RTC_WAKEUPCLOCK_CKSPRE);
+  //LL_RTC_WAKEUP_SetAutoReload(RTC, 0);
+  //LL_RTC_WAKEUP_SetClock(RTC, LL_RTC_WAKEUPCLOCK_CKSPRE);
   
   /* Enable wake up counter and wake up interrupt */
-  LL_RTC_WAKEUP_Enable(RTC);
-  LL_RTC_EnableIT_WUT(RTC);
-  LL_RTC_ClearFlag_WUT(RTC);
+  //LL_RTC_WAKEUP_Enable(RTC);
+  //LL_RTC_EnableIT_WUT(RTC);
+  //LL_RTC_ClearFlag_WUT(RTC);
   
   /* Enable RTC registers write protection */
-  LL_RTC_EnableWriteProtection(RTC);
+  //LL_RTC_EnableWriteProtection(RTC);
  /* LSI_CLOCK,
   HSI_CLOCK,
   LSE_CLOCK,
   HSE_CLOCK*/
-#endif
+#endif /* USE_TIMEOUT */
 }
 
 /**

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -713,6 +713,7 @@ void RTC_Alarm_IRQHandler(void)
   HAL_RTC_AlarmIRQHandler(&RtcHandle);
 }
 
+#if defined(STM32F1xx)
 /**
   * @brief Attach Seconds interrupt callback.
   * @param func: pointer to the callback
@@ -759,6 +760,7 @@ void RTC_IRQHandler(void)
 {
   HAL_RTCEx_RTCIRQHandler(&RtcHandle);
 }
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -794,7 +794,7 @@ void RTC_IRQHandler(void)
   * @param  htim Timer handle
   * @retval None
  */
-void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef* htim)
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
   UNUSED(htim);
 

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -740,7 +740,6 @@ void attachSecondsIrqCallback(voidCallbackPtr func)
   //LL_RTC_WAKEUP_Enable(RTC);
   //LL_RTC_EnableIT_WUT(RTC);
   //LL_RTC_ClearFlag_WUT(RTC);
-  
   /* Enable RTC registers write protection */
   //LL_RTC_EnableWriteProtection(RTC);
  /* LSI_CLOCK,

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -742,10 +742,10 @@ void attachSecondsIrqCallback(voidCallbackPtr func)
   //LL_RTC_ClearFlag_WUT(RTC);
   /* Enable RTC registers write protection */
   //LL_RTC_EnableWriteProtection(RTC);
- /* LSI_CLOCK,
-  HSI_CLOCK,
-  LSE_CLOCK,
-  HSE_CLOCK*/
+  /* LSI_CLOCK,
+   HSI_CLOCK,
+   LSE_CLOCK,
+   HSE_CLOCK*/
 #endif /* USE_TIMEOUT */
 }
 

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -736,7 +736,6 @@ void attachSecondsIrqCallback(voidCallbackPtr func)
        this allows to get a wakeup time equal to 1 s if the counter is 0x0 */
   //LL_RTC_WAKEUP_SetAutoReload(RTC, 0);
   //LL_RTC_WAKEUP_SetClock(RTC, LL_RTC_WAKEUPCLOCK_CKSPRE);
-  
   /* Enable wake up counter and wake up interrupt */
   //LL_RTC_WAKEUP_Enable(RTC);
   //LL_RTC_EnableIT_WUT(RTC);

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -86,8 +86,6 @@ typedef void(*voidCallbackPtr)(void *);
 #endif
 
 
-
-
 #define HSE_RTC_MAX 1000000U
 
 #if !defined(STM32F1xx)

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -165,6 +165,9 @@ void RTC_GetAlarm(uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *secon
 void attachAlarmCallback(voidCallbackPtr func, void *data);
 void detachAlarmCallback(void);
 
+void attachSecondsIrqCallback(voidCallbackPtr func);
+void detachSecondsIrqCallback();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -165,8 +165,10 @@ void RTC_GetAlarm(uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *secon
 void attachAlarmCallback(voidCallbackPtr func, void *data);
 void detachAlarmCallback(void);
 
+#if defined(STM32F1xx)
 void attachSecondsIrqCallback(voidCallbackPtr func);
 void detachSecondsIrqCallback();
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -86,6 +86,8 @@ typedef void(*voidCallbackPtr)(void *);
 #endif
 
 
+
+
 #define HSE_RTC_MAX 1000000U
 
 #if !defined(STM32F1xx)
@@ -165,10 +167,8 @@ void RTC_GetAlarm(uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *secon
 void attachAlarmCallback(voidCallbackPtr func, void *data);
 void detachAlarmCallback(void);
 
-#if defined(STM32F1xx)
 void attachSecondsIrqCallback(voidCallbackPtr func);
 void detachSecondsIrqCallback();
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
**Implement the built-in Seconds interrupt functionality**

Currently working for stm32f1xx only as the core code is already in place. I would like to implement this feature for all variants but the core HAL drivers for each variant would need to be updated to enable the seconds interrupt.

Requires core > 1.9.0 so that rtc.h and rtc.c are included from this library.

**EDIT**
_It looks like this interrupt is not available on other variants.
For all variants that don't support the Seconds Interrupt, this could be implemented using AlarmB since its not currently accessible, might need to be able to choose between enable Seconds Interrupts or enable AlarmB to make it safe on these variants if AlarmB is going to be implemented in a future version though?_

_Using RTC in F0, F2, F3, F4 and L1 [App note AN3371](https://www.st.com/content/ccc/resource/technical/document/application_note/7a/9c/de/da/84/e7/47/8a/DM00025071.pdf/files/DM00025071.pdf/jcr:content/translations/en.DM00025071.pdf)_