### PR TITLE
stm32F1 set/get prescaler div interface change

### DIFF
--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -133,6 +133,19 @@ void STM32RTC::setClockSource(Source_Clock source)
   }
 }
 
+#if defined(STM32F1xx)
+/**
+  * @brief  get user asynchronous prescaler value for the current clock source.
+  * @param  predivA: pointer to the current Asynchronous prescaler value
+  * @param  dummy : not used (kept for compatibility reason)
+  * @retval None
+  */
+void STM32RTC::getPrediv(uint32_t *predivA, int16_t *dummy)
+{
+  UNUSED(dummy);
+  RTC_getPrediv(predivA);
+}
+#else
 /**
   * @brief  get user (a)synchronous prescaler values if set else computed
   *         ones for the current clock source.
@@ -146,7 +159,22 @@ void STM32RTC::getPrediv(int8_t *predivA, int16_t *predivS)
     RTC_getPrediv(predivA, predivS);
   }
 }
+#endif /* STM32F1xx */
 
+#if defined(STM32F1xx)
+/**
+  * @brief  set user asynchronous prescalers value.
+  * @note   This method must be called before begin().
+  * @param  predivA: Asynchronous prescaler value. Reset value: RTC_AUTO_1_SECOND
+  * @param  dummy : not used (kept for compatibility reason)
+  * @retval None
+  */
+void STM32RTC::setPrediv(uint32_t predivA, int16_t dummy)
+{
+  UNUSED(dummy);
+  RTC_setPrediv(predivA);
+}
+#else
 /**
   * @brief  set user (a)synchronous prescalers value.
   * @note   This method must be called before begin().
@@ -158,6 +186,7 @@ void STM32RTC::setPrediv(int8_t predivA, int16_t predivS)
 {
   RTC_setPrediv(predivA, predivS);
 }
+#endif /* STM32F1xx */
 
 /**
   * @brief enable the RTC alarm.

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -189,9 +189,13 @@ class STM32RTC {
     void setY2kEpoch(uint32_t ts);
     void setAlarmEpoch(uint32_t ts, Alarm_Match match = MATCH_DHHMMSS, uint32_t subSeconds = 0);
 
+#if defined(STM32F1xx)
+    void getPrediv(uint32_t *predivA, int16_t *dummy = nullptr);
+    void setPrediv(uint32_t predivA, int16_t dummy = 0);
+#else
     void getPrediv(int8_t *predivA, int16_t *predivS);
     void setPrediv(int8_t predivA, int16_t predivS);
-
+#endif /* STM32F1xx */
     bool isConfigured(void)
     {
       return _configured;

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -94,6 +94,9 @@ typedef void(*voidCallbackPtr)(void *);
 #endif
 #define PREDIVA_MAX (RTC_PRER_PREDIV_A >> RTC_PRER_PREDIV_A_Pos)
 #define PREDIVS_MAX (RTC_PRER_PREDIV_S >> RTC_PRER_PREDIV_S_Pos)
+#else
+/* for stm32F1 the MAX value is combining PREDIV low & high registers */
+#define PREDIVA_MAX 0xFFFFFU
 #endif /* !STM32F1xx */
 
 #if defined(STM32F0xx) || defined(STM32L0xx) || \
@@ -135,9 +138,13 @@ static uint32_t RTC_getSource(void) {
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
 void RTC_SetClockSource(sourceClock_t source);
-
+#if defined(STM32F1xx)
+void RTC_getPrediv(uint32_t *asynch);
+void RTC_setPrediv(uint32_t asynch);
+#else
 void RTC_getPrediv(int8_t *asynch, int16_t *synch);
 void RTC_setPrediv(int8_t asynch, int16_t synch);
+#endif /* STM32F1xx */
 
 void RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
 void RTC_DeInit(void);


### PR DESCRIPTION
This PR is defining the set/getPrediv  functions in case of stm32F1 
With this soc device, the prescaler is a 32bit value corresponding to the DIV registers (read-only) or PREScaler registers (write-only). This configuration is adapted to keep the interface unchanged for other soc.
The `prediv` variable is keeping the value read or written.
The RTC_init is not changed.

This PR is another way of the https://github.com/stm32duino/STM32RTC/pull/38

Requires the change in the stm32duino/STM32Examples : https://github.com/stm32duino/STM32Examples/pull/53

Signed-off-by: Francois Ramu <francois.ramu@st.com>



