### PR TITLE
implement a One-Second interrupt on stm32 MCUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ _Library version management_
 #endif
 ```
 
+### Since STM32RTC version higher than 1.1.1
+
+_One-Second interrupt_
+
+  STM32 RTC includes a one-second interrupt for generating a periodic interrupt signal.
+  - This feature is native on the stm32F1xx and mapped on the existing WakeUp interrupt on other stm32 mcus. 
+  - It is not available on some stm32F0 devices.
+
+  * **new API:**
+    * **`void attachSecondsInterrupt(voidFuncPtr callback)`**
+    * **`void detachSecondsInterrupt(void)`**
+
+
+
 ### Since STM32 Core version > 1.5.0
 _Reset time management_
 
@@ -118,10 +132,10 @@ To know if a time has already been set use:
   }
 ```
 
-Refer to the Arduino RTC documentation for the other functions  
+Refer to the Arduino RTC documentation for the other functions
 http://arduino.cc/en/Reference/RTC
 
 ## Source
 
-Source files available at:  
+Source files available at:
 https://github.com/stm32duino/STM32RTC

--- a/examples/RTC_Seconds/RTC_Seconds.ino
+++ b/examples/RTC_Seconds/RTC_Seconds.ino
@@ -1,0 +1,113 @@
+/*
+  RTC_Seconds
+
+  This sketch allows to test STM32RTC Seconds IRQ.
+
+  Creation 25 nov 2021
+  by FRASTM for STMicroelectronics
+
+  This example code is in the public domain.
+
+  Note that this sketch is valid for STM32F1xx or stm32 MCU with WakeUp interrupt
+       (WUTE flag present in the RTC CR register)
+
+  https://github.com/stm32duino/STM32RTC
+
+*/
+
+#include <STM32RTC.h>
+
+#ifndef ONESECOND_IRQn
+#error "RTC has no feature for One-Second interrupt"
+#endif
+
+/* use led to display seconds */
+#if defined(LED_BUILTIN)
+#define pin  LED_BUILTIN
+#endif
+
+/* Get the rtc object */
+STM32RTC& rtc = STM32RTC::getInstance();
+
+/* Change these values to set the current initial time
+
+   format: date: "Dec 31 2017" and time: "23:59:56"
+   by default use built date and time
+*/
+/* Change these values to set the current initial time */
+const byte seconds = 0;
+const byte minutes = 5;
+const byte hours = 11;
+
+/* Change these values to set the current initial date */
+/* Monday 25 Nov. 2021 */
+const byte weekDay = 4;
+const byte day = 25;
+const byte month = 11;
+const byte year = 21;
+
+bool toggling = false; // changed each second by the CallBack function
+
+static STM32RTC::Hour_Format hourFormat = STM32RTC::HOUR_24;
+static STM32RTC::AM_PM period = STM32RTC::AM;
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial) {}
+
+#if defined(LED_BUILTIN)
+  // configure pin in output mode
+  pinMode(pin, OUTPUT);
+  digitalWrite(pin, HIGH);
+#endif /* LED_BUILTIN */
+
+  Serial.print("RTC Init ");
+
+  // Select RTC clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK.
+  // By default the LSI is selected as source. Use LSE for better accuracy if available
+  // rtc.setClockSource(STM32RTC::LSE_CLOCK);
+
+  // initialize RTC 24H format
+  rtc.begin(hourFormat);
+
+  // Set the time
+  rtc.setHours(hours, period);
+  rtc.setMinutes(minutes);
+  rtc.setSeconds(seconds);
+
+  // Set the date
+  rtc.setWeekDay(weekDay);
+  rtc.setDay(day);
+  rtc.setMonth(month);
+  rtc.setYear(year);
+
+  Serial.println("with seconds Alarm");
+  rtc.attachSecondsInterrupt(rtc_SecondsCB);
+}
+
+void loop()
+{
+  uint8_t sec = 0;
+  uint8_t mn = 0;
+  uint8_t hrs = 0;
+  uint32_t subs = 0;
+  rtc.getTime(&hrs, &mn, &sec, &subs);
+
+  if (toggling) {
+   Serial.printf("%02d:%02d:%02d\n", hrs, mn, sec);
+  } else {
+   Serial.printf("%02d %02d %02d\n", hrs, mn, sec);
+  }
+#if defined(LED_BUILTIN)
+  digitalWrite(pin, toggling);
+#endif /* LED_BUILTIN */
+  delay(1000);
+}
+
+/* callback function on each second interrupt */
+void rtc_SecondsCB(void *data)
+{
+  UNUSED(data);
+  toggling = !toggling;
+}

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -249,6 +249,27 @@ void STM32RTC::detachInterrupt(void)
   detachAlarmCallback();
 }
 
+#ifdef ONESECOND_IRQn
+/**
+  * @brief attach a callback to the RTC Seconds interrupt.
+  * @param callback: pointer to the callback
+  * @retval None
+  */
+void STM32RTC::attachSecondsInterrupt(voidFuncPtr callback)
+{
+  attachSecondsIrqCallback(callback);
+}
+
+/**
+  * @brief detach the RTC Seconds callback.
+  * @retval None
+  */
+void STM32RTC::detachSecondsInterrupt(void)
+{
+  detachSecondsIrqCallback();
+}
+
+#endif /* ONESECOND_IRQn */
 // Kept for compatibility. Use STM32LowPower library.
 void STM32RTC::standbyMode(void)
 {

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -125,6 +125,12 @@ class STM32RTC {
     void attachInterrupt(voidFuncPtr callback, void *data = nullptr);
     void detachInterrupt(void);
 
+#ifdef ONESECOND_IRQn
+    // Other mcu than stm32F1 will use the WakeUp feature to interrupt each second.
+    void attachSecondsInterrupt(voidFuncPtr callback);
+    void detachSecondsInterrupt(void);
+
+#endif /* ONESECOND_IRQn */
     // Kept for compatibility: use STM32LowPower library.
     void standbyMode();
 

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -109,6 +109,28 @@ typedef void(*voidCallbackPtr)(void *);
 #define RTC_Alarm_IRQHandler RTC_TAMP_IRQHandler
 #endif
 
+/* mapping the IRQn for the one-second interrupt depending on the soc */
+#if defined(STM32F1xx) || (defined(STM32F0xx) && defined(RTC_CR_WUTE)) || \
+    defined(STM32L0xx) || defined(STM32L5xx) || defined(STM32U5xx) || \
+    defined(STM32WLE4xx)
+// specific WakeUp interrupt
+#define ONESECOND_IRQn RTC_IRQn
+#elif defined(STM32MP1xx)
+// global RTC interrupt
+#define ONESECOND_IRQn RTC_WKUP_ALARM_IRQn
+#elif defined(STM32G0xx)
+// global RTC/TAMP interrupt
+#define ONESECOND_IRQn RTC_TAMP_IRQn
+#elif defined(STM32WL54xx)|| defined(STM32WL55xx)
+// global RTC/LSS interrupt
+#define ONESECOND_IRQn RTC_LSECSS_IRQn
+#elif defined(RTC_CR_WUTE)
+// specific WakeUp interrupt (including M4 cpu of the STM32WLE5xx)
+#define ONESECOND_IRQn RTC_WKUP_IRQn
+#else
+// no One-Second IRQ available for the series
+#endif /* STM32F1xx || etc */
+
 #if defined(STM32F1xx) && !defined(IS_RTC_WEEKDAY)
 /* Compensate missing HAL definition */
 #define IS_RTC_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
@@ -161,6 +183,10 @@ void RTC_StopAlarm(void);
 void RTC_GetAlarm(uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *subSeconds, hourAM_PM_t *period, uint8_t *mask);
 void attachAlarmCallback(voidCallbackPtr func, void *data);
 void detachAlarmCallback(void);
+#ifdef ONESECOND_IRQn
+void attachSecondsIrqCallback(voidCallbackPtr func);
+void detachSecondsIrqCallback(void);
+#endif /* ONESECOND_IRQn */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This Enhancement is adding a interrupt on each second for the stm32xx MCUs
 
for the stm32F1 : the RTC One-Second flag interrupt is asserted on each RTC Core 1Hz clock cycle 
for other MCUS the RTC WakeUP feature is programmed to interrupt each second
 depending on the stm32 serie, this interrupt channel is a global or a specific one.
In the the stm32F0xx serie, other than STM32F071xB, STM32F072xB, STM32F078xx, STM32F091xC, STM32F098xx, STM32F070xB, STM32F030xC do not support the WakeUp capability.


A simple example _RTC_Seconds_  demonstrating the feature with a basic callback function that toggle a bit each second
This test is passed on stm32F1 (nucleo f103rb), stm32G4 (nucleo g474re), stm32L4 (nucleo l476rg), stm32WB (nucleo wb55rg), stm32L1 (nucleo l152re), stm32F7 (nucleo 144 f767zi)

This PR is inspired by the https://github.com/stm32duino/STM32RTC/pull/42

Fixes https://github.com/stm32duino/STM32RTC/issues/3

Signed-off-by: Francois Ramu <francois.ramu@st.com>