### PR TITLE
Adds date retention in the backup memory for the stm32f1xx

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ _One-Second interrupt_
     * **`void detachSecondsInterrupt(void)`**
 
 
+_Date retention for stm32F1xx_
+
+  STM32 RTC includes date save/retrieve mechanism for the stm32F1xx mcu, that do not have a date counter.
+
+  The content is stored in BackUp memory which is kept during Reset and powered by Vbat when the Vdd is off.
+
 
 ### Since STM32 Core version > 1.5.0
 _Reset time management_

--- a/examples/F1RTCDateRetention/F1RTCDateRetention.ino
+++ b/examples/F1RTCDateRetention/F1RTCDateRetention.ino
@@ -1,0 +1,103 @@
+/*
+  F1RTCDateRetention
+
+  This sketch shows how to keep the RTC date with backup registers on a stm32F1 MCU.
+  It is reserved for stm32F1 as other devices actually embed the feature.
+  If a VBat is present on the target board, then the content is kept when
+  the VDD power supply is off, else the content is reset
+
+  Creation 03 dec 2021
+  by FRASTM for STMicroelectronics
+
+  This example code is in the public domain.
+
+  https://github.com/stm32duino/STM32RTC
+*/
+
+#include <STM32RTC.h>
+
+/* Get the rtc object */
+STM32RTC& rtc = STM32RTC::getInstance();
+
+#if !defined(STM32F1xx)
+#error "Not applicable (only stm32F1xx save date in backup memory)"
+#endif /* !STM32F1xx */
+
+#define INITIAL_SEC 53
+#define INITIAL_MIN 59
+#define INITIAL_HOUR 23
+#define INITIAL_WDAY 2
+#define INITIAL_DAY 7
+#define INITIAL_MONTH 12
+#define INITIAL_YEAR 21
+
+uint32_t subSec;
+byte seconds;
+byte minutes;
+byte hours;
+byte am_pm;
+
+/* these values are read in the backUp register */
+byte weekDay;
+byte day;
+byte month;
+byte year;
+
+void setup()
+{
+  Serial.begin(115200);
+
+  // Select RTC clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK.
+  // By default the LSI is selected as source.
+  //rtc.setClockSource(STM32RTC::LSE_CLOCK);
+
+  // true: reset the backUp register (restart from the initial date/time above on each reset)
+  // false: keep the latest date from the BackUp register on each reset
+  bool reset_bkup = false;
+  rtc.begin(reset_bkup); // initialize RTC 24H format
+  // get the date if stored in BackUp reg
+  rtc.getDate(&weekDay, &day, &month, &year);
+  if (reset_bkup) {
+    Serial.printf("reset the date to %02d/%02d/%02d\n", day, month, year);
+  } else {
+    Serial.printf("date from the BackUp %02d/%02d/%02d\n", day, month, year);
+  }
+
+  // Check if date is valid = read in the backUp reg.
+  // Note that backup reg only keep the date /time
+  // and a power off reset the content if not saved by Vbat
+  // HAL_RTC init date is set to 1st of January 2000
+if ((day == 1) && (month == RTC_MONTH_JANUARY) && (year == 0)) {
+    // Set the time
+    rtc.setHours(INITIAL_HOUR);
+    rtc.setMinutes(INITIAL_MIN);
+    rtc.setSeconds(INITIAL_SEC);
+
+    // Set the date
+    rtc.setWeekDay(INITIAL_WDAY);
+    rtc.setDay(INITIAL_DAY);
+    rtc.setMonth(INITIAL_MONTH);
+    rtc.setYear(INITIAL_YEAR);
+
+    // Here you can also use
+    //rtc.setTime(hours, minutes, seconds);
+    //rtc.setDate(weekDay, day, month, year);
+  }
+}
+
+void loop()
+{
+  // Print date...
+  Serial.printf("%02d/%02d/%02d \t", rtc.getDay(), rtc.getMonth(), rtc.getYear());
+
+  uint8_t sec = 0;
+  uint8_t mn = 0;
+  uint8_t hrs = 0;
+  uint32_t subs = 0;
+  rtc.getTime(&hrs, &mn, &sec, &subs);
+
+  // ...and time
+  Serial.printf("%02d:%02d:%02d\n", hrs, mn, sec);
+
+  delay(1000);
+}

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -77,6 +77,16 @@ typedef enum {
 typedef void(*voidCallbackPtr)(void *);
 
 /* Exported constants --------------------------------------------------------*/
+
+#if defined(STM32F1xx)
+/* select 32 bits in backup memory to store date.
+   2 consecutive 16bit reg. are reserved: RTC_BKP_DATE & RTC_BKP_DATE + 1 */
+#if !defined(RTC_BKP_DATE)
+/* can be changed for your convenience (here : LL_RTC_BKP_DR6 & LL_RTC_BKP_DR7) */
+#define RTC_BKP_DATE LL_RTC_BKP_DR6
+#endif
+#endif /* STM32F1xx */
+
 /* Interrupt priority */
 #ifndef RTC_IRQ_PRIO
 #define RTC_IRQ_PRIO       2
@@ -187,6 +197,10 @@ void detachAlarmCallback(void);
 void attachSecondsIrqCallback(voidCallbackPtr func);
 void detachSecondsIrqCallback(void);
 #endif /* ONESECOND_IRQn */
+
+#if defined(STM32F1xx)
+void RTC_StoreDate(void);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds a RTC date retention for the stm32F1 MCUs. 
This new feature is saving/restoring the date (year, month, day, weekday) in the backup memory of he MCUs.
On the stm32F1, the Date is not present in the RTC peripheral but computed by the RTC driver.
The BackUp memory of the stm32F1 is powered by the VBat  when VDD is switched off.
It is not altered by the system Reset.

Each one-byte element of the RTC Date (DateToUpdate) is well placed in two contiguous 16bit backup registers (RTC_BKP_DATE, RTC_BKP_DATE + 1).  The registers are arbitrary selected to store the date and can be easily changed in the `rtc.h  `to choose other memory positions.

Moreover, for the stm32F1, the  'reset' flag is now available in the `RTC::begin` to reset the content of the backUp register.
Note that the reset value of the RTC date in the stm32F1 is '01/01/2000'

A simple RTC _examples/backupRTC_ is given to demonstrate this feature (--> test with different the `reset_bkup` bool values).

This PR is inspired by the https://github.com/stm32duino/STM32RTC/pull/41

Fixes #32

Signed-off-by: Francois Ramu francois.ramu@st.com