### PR TITLE
refactor: Improve reliability and simplify implementation

### DIFF
--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -204,16 +204,16 @@ class STM32RTC {
 #endif /* STM32F1xx */
     bool isConfigured(void)
     {
-      return _configured;
+      return RTC_IsConfigured();
     }
     bool isAlarmEnabled(void)
     {
-      return _alarmEnabled;
+      return RTC_IsAlarmSet();
     }
     bool isTimeSet(void)
     {
 #if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01050000)
-      return RTC_IsTimeSet();
+      return _timeSet;
 #else
       return false;
 #endif
@@ -224,8 +224,7 @@ class STM32RTC {
   private:
     STM32RTC(void): _clockSource(LSI_CLOCK) {}
 
-    static bool _configured;
-    static bool _reset;
+    static bool _timeSet;
 
     Hour_Format _format;
     AM_PM       _hoursPeriod;
@@ -245,7 +244,6 @@ class STM32RTC {
     uint32_t    _alarmSubSeconds;
     AM_PM       _alarmPeriod;
     Alarm_Match _alarmMatch;
-    bool        _alarmEnabled;
 
     Source_Clock _clockSource;
 

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -178,9 +178,9 @@ void RTC_getPrediv(int8_t *asynch, int16_t *synch);
 void RTC_setPrediv(int8_t asynch, int16_t synch);
 #endif /* STM32F1xx */
 
-void RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
+bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
 void RTC_DeInit(void);
-bool RTC_IsTimeSet(void);
+bool RTC_IsConfigured(void);
 
 void RTC_SetTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period);
 void RTC_GetTime(uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *subSeconds, hourAM_PM_t *period);
@@ -190,6 +190,7 @@ void RTC_GetDate(uint8_t *year, uint8_t *month, uint8_t *day, uint8_t *wday);
 
 void RTC_StartAlarm(uint8_t day, uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period, uint8_t mask);
 void RTC_StopAlarm(void);
+bool RTC_IsAlarmSet(void);
 void RTC_GetAlarm(uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *subSeconds, hourAM_PM_t *period, uint8_t *mask);
 void attachAlarmCallback(voidCallbackPtr func, void *data);
 void detachAlarmCallback(void);


### PR DESCRIPTION
refactor: Improve reliability and simplify implementation

* call HAL_RTC_Init() only when needed to avoid losing hundreds
  of milliseconds on RTC counter
* remove useless check of _configured at the beginning of
  STM32RTC class methods
* Use flag "INITS" to detect whether RTC calendar is initialized
  (except for F1 which doesn't have this flag)
  This prevent the use of year 2000 which is the default hardware
  reset value and doesn't trigger INITS flag
* Use Backup registers only for F1, and no more for other series
* Simplify class state management:
  - remove _configured and _reset, _alarmEnabled
  - add _timeSet

Tested on BluePill and Nucleo L476RG, with examples from STM32duino_RTC library

fixes #66
