### PR TITLE
fix: in configForLowPower(), begin() should be call unconditionnally

### DIFF
--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -926,39 +926,36 @@ void STM32RTC::configForLowPower(Source_Clock source)
 #ifdef __HAL_RCC_RTCAPB_CLKAM_ENABLE
   __HAL_RCC_RTCAPB_CLKAM_ENABLE();
 #endif
-  if (!RTC_IsConfigured()) {
+
+  begin();
+
+  if (_clockSource != source) {
+    // Save current config
+    AM_PM period, alarmPeriod = _alarmPeriod;
+    uint32_t subSeconds;
+    uint8_t seconds, minutes, hours, weekDay, day, month, years;
+    uint8_t alarmSeconds, alarmMinutes, alarmHours, alarmDay;
+    Alarm_Match alarmMatch = _alarmMatch;
+
+    alarmDay = _alarmDay;
+    alarmHours = _alarmHours;
+    alarmMinutes = _alarmMinutes;
+    alarmSeconds = _alarmSeconds;
+
+    getDate(&weekDay, &day, &month, &years);
+    getTime(&seconds, &minutes, &hours, &subSeconds, &period);
+
+    end();
     _clockSource = source;
     // Enable RTC
-    begin();
-  } else {
-    if (_clockSource != source) {
-      // Save current config
-      AM_PM period, alarmPeriod = _alarmPeriod;
-      uint32_t subSeconds;
-      uint8_t seconds, minutes, hours, weekDay, day, month, years;
-      uint8_t alarmSeconds, alarmMinutes, alarmHours, alarmDay;
-      Alarm_Match alarmMatch = _alarmMatch;
-
-      alarmDay = _alarmDay;
-      alarmHours = _alarmHours;
-      alarmMinutes = _alarmMinutes;
-      alarmSeconds = _alarmSeconds;
-
-      getDate(&weekDay, &day, &month, &years);
-      getTime(&seconds, &minutes, &hours, &subSeconds, &period);
-
-      end();
-      _clockSource = source;
-      // Enable RTC
-      begin(period);
-      // Restore config
-      setTime(seconds, minutes, hours, subSeconds, period);
-      setDate(weekDay, day, month, years);
-      setAlarmTime(alarmHours, alarmMinutes, alarmSeconds, alarmPeriod);
-      setAlarmDay(alarmDay);
-      if (RTC_IsAlarmSet()) {
-        enableAlarm(alarmMatch);
-      }
+    begin(period);
+    // Restore config
+    setTime(seconds, minutes, hours, subSeconds, period);
+    setDate(weekDay, day, month, years);
+    setAlarmTime(alarmHours, alarmMinutes, alarmSeconds, alarmPeriod);
+    setAlarmDay(alarmDay);
+    if (RTC_IsAlarmSet()) {
+      enableAlarm(alarmMatch);
     }
   }
 #endif

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -948,7 +948,7 @@ void STM32RTC::configForLowPower(Source_Clock source)
     end();
     _clockSource = source;
     // Enable RTC
-    begin(period);
+    begin(_format);
     // Restore config
     setTime(seconds, minutes, hours, subSeconds, period);
     setDate(weekDay, day, month, years);
@@ -957,6 +957,11 @@ void STM32RTC::configForLowPower(Source_Clock source)
     if (RTC_IsAlarmSet()) {
       enableAlarm(alarmMatch);
     }
+  }
+
+  if (!isTimeSet()) {
+    // Set arbitrary time for Lowpower; if not already set
+    setTime(12, 0, 0, 0, AM);
   }
 #endif
 }

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -355,6 +355,7 @@ bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
 
   if (reset) {
     resetBackupDomain();
+    RTC_initClock(source);
   }
 
 #if defined(STM32F1xx)
@@ -401,9 +402,6 @@ bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
   /* Enable Direct Read of the calendar registers (not through Shadow) */
   HAL_RTCEx_EnableBypassShadow(&RtcHandle);
 #endif
-
-  HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
-  HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
 
   return reinit;
 }
@@ -654,6 +652,8 @@ void RTC_StartAlarm(uint8_t day, uint8_t hours, uint8_t minutes, uint8_t seconds
 
     /* Set RTC_Alarm */
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
+    HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
+    HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
   }
 }
 


### PR DESCRIPTION
fix: in configForLowPower(), begin() should be call unconditionnally

The fact RTC is already configured or not,
is handled by begin() itself.
Fixes https://github.com/stm32duino/STM32LowPower/issues/71

Signed-off-by: Alexandre Bourdiol <alexandre.bourdiol@st.com>