### PR TITLE
Add support for both Alarm_A and Alarm_B

### DIFF
--- a/examples/RTC_Alarm_A_B/RTC_Alarm_A_B.ino
+++ b/examples/RTC_Alarm_A_B/RTC_Alarm_A_B.ino
@@ -1,0 +1,56 @@
+/*
+  SimpleRTC
+
+  This sketch shows how to configure the RTC 
+  for two separate interrupts
+
+  This example code is in the public domain.
+
+  https://github.com/stm32duino/STM32RTC
+*/
+
+#define SERIAL_ENABLED
+#ifdef __AVR__
+#define TheSerial Serial
+#else
+#include "HardwareSerial.h"
+//                     RX   TX
+HardwareSerial Serial2(PA3, PA2);
+#define TheSerial Serial2
+#endif
+
+#include <STM32RTC.h>
+
+/* Get the rtc object */
+STM32RTC& rtc = STM32RTC::getInstance();
+
+const byte alarm_a_second = 30;
+const byte alarm_b_second = 12;
+
+void setup()
+{
+  TheSerial.begin(38400);
+
+  rtc.begin();
+  rtc.setAlarmType(RTC_ALARM_A);
+  rtc.attachInterrupt(alarmACallback, NULL);
+  rtc.setAlarmEpoch(rtc.getEpoch() + alarm_a_second);
+  
+  rtc.setAlarmType(RTC_ALARM_B);
+  rtc.attachInterrupt(alarmBCallback, NULL);
+  rtc.setAlarmEpoch(rtc.getEpoch() + alarm_b_second);
+}
+
+void loop()
+{
+}
+
+void alarmACallback(void *data)
+{
+  TheSerial.println("Alarm A called");
+}
+
+void alarmBCallback(void *data)
+{
+  TheSerial.println("Alarm A called");
+}

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -135,6 +135,7 @@ class STM32RTC {
     void standbyMode();
 
     /* Get Functions */
+    uint32_t getAlarmType(void);
 
     uint32_t getSubSeconds(void);
     uint8_t getSeconds(void);
@@ -160,6 +161,7 @@ class STM32RTC {
     uint8_t getAlarmYear();
 
     /* Set Functions */
+    void setAlarmType(uint32_t alarmType);
 
     void setSubSeconds(uint32_t subSeconds);
     void setSeconds(uint8_t seconds);
@@ -225,6 +227,8 @@ class STM32RTC {
     STM32RTC(void): _clockSource(LSI_CLOCK) {}
 
     static bool _timeSet;
+
+    uint32_t    _alarmType;
 
     Hour_Format _format;
     AM_PM       _hoursPeriod;

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -194,6 +194,13 @@ bool RTC_IsAlarmSet(void);
 void RTC_GetAlarm(uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *subSeconds, hourAM_PM_t *period, uint8_t *mask);
 void attachAlarmCallback(voidCallbackPtr func, void *data);
 void detachAlarmCallback(void);
+
+void v2_RTC_StartAlarm(uint32_t alarmType, uint8_t day, uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period, uint8_t mask);
+void v2_RTC_StopAlarm(uint32_t alarmType);
+bool v2_RTC_IsAlarmSet(uint32_t alarmType);
+void v2_RTC_GetAlarm(uint32_t alarmType, uint8_t *day, uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *subSeconds, hourAM_PM_t *period, uint8_t *mask);
+void v2_attachAlarmCallback(uint32_t alarmType, voidCallbackPtr func, void *data);
+void v2_detachAlarmCallback(uint32_t alarmType);
 #ifdef ONESECOND_IRQn
 void attachSecondsIrqCallback(voidCallbackPtr func);
 void detachSecondsIrqCallback(void);


### PR DESCRIPTION
The code is far from perfect, but it does what it is intended to.

You can call now `rtc.setAlarmType(RTC_ALARM_B);` to set up second timer.