### PR TITLE
fix: ability to set alarm after reset

### DIFF
--- a/examples/F1RTCDateRetention/F1RTCDateRetention.ino
+++ b/examples/F1RTCDateRetention/F1RTCDateRetention.ino
@@ -66,8 +66,9 @@ void setup()
   // Check if date is valid = read in the backUp reg.
   // Note that backup reg only keep the date /time
   // and a power off reset the content if not saved by Vbat
-  // HAL_RTC init date is set to 1st of January 2000
-if ((day == 1) && (month == RTC_MONTH_JANUARY) && (year == 0)) {
+  // Stm32duino RTC init date is set to 1st of January 2001
+  // https://github.com/stm32duino/STM32RTC/blob/f620b534f7bffe24f031fc5935324027cfe51320/src/rtc.c#L395
+if ((day == 1) && (month == RTC_MONTH_JANUARY) && (year == 1)) {
     // Set the time
     rtc.setHours(INITIAL_HOUR);
     rtc.setMinutes(INITIAL_MIN);


### PR DESCRIPTION
fix: ability to set alarm after reset

Be sure to set default value for alarmday,
and thus avoid IS_RTC_DATE(day) being false
when is not usd in alarm setting

Take into account Reset usecase
(being able to set new alarma after a reset)

Factorize change of RTC clock source in the RTC_begin() function which imply a reset of BackupDomain.
Save configuration before this BackupDomain reset, and restore after.

Tested with sketches from RTC and LowPower libraries,
on both Nucleo F103RB and Nucleo L476RG

fixes stm32duino/STM32LowPower#82
