### PR TITLE
fix: 1 RTC vector for both HAL IRQHandler Alarm and WakeUpTimer

### DIFF
--- a/src/rtc.c
+++ b/src/rtc.c
@@ -863,6 +863,12 @@ void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
 void RTC_Alarm_IRQHandler(void)
 {
   HAL_RTC_AlarmIRQHandler(&RtcHandle);
+
+#if defined(STM32F0xx) || defined(STM32G0xx) || defined(STM32L0xx) || defined(STM32L5xx) || defined(STM32U5xx)
+  // In some cases, the same vector is used to manage WakeupTimer,
+  // but with a dedicated HAL IRQHandler
+  HAL_RTCEx_WakeUpTimerIRQHandler(&RtcHandle);
+#endif
 }
 
 #ifdef ONESECOND_IRQn


### PR DESCRIPTION
fix: 1 RTC vector for both HAL IRQHandler Alarm and WakeUpTimer

Sometimes, both HAL IRQ handler should be call from RTC vector
* HAL_RTC_AlarmIRQHandler()
* HAL_RTCEx_WakeUpTimerIRQHandler()

Fixes #78 