### PR TITLE
fix(F1): properly update date

### DIFF
--- a/src/rtc.c
+++ b/src/rtc.c
@@ -485,6 +485,8 @@ bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
       RTC_initClock(source);
 #if defined(STM32F1xx)
       memcpy(&RtcHandle.DateToUpdate, &BackupDate, 4);
+      /* Update date automatically by calling HAL_RTC_GetDate */
+      RTC_GetDate(&years, &month, &days, &weekDay);
       /* and fill the new RTC Date value */
       RTC_SetDate(RtcHandle.DateToUpdate.Year, RtcHandle.DateToUpdate.Month,
                   RtcHandle.DateToUpdate.Date, RtcHandle.DateToUpdate.WeekDay);


### PR DESCRIPTION
Fixes #87

When RTC init after power off (only VBAT available), after restore date from backup register in the RTC hadnle,  `HAL_RTC_GetDate` is called to update date automatically based on counter time value else if one or more day elapsed it is not take in account.
