### PR TITLE
STM32RTC: syncAlarmTime Get the Alarm given by the parameter

### DIFF
--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -1276,7 +1276,7 @@ void STM32RTC::syncAlarmTime(Alarm name)
     RTC_GetAlarm(::ALARM_B, &_alarmBDay, &_alarmBHours, &_alarmBMinutes, &_alarmBSeconds,
                  &_alarmBSubSeconds, &p, &match);
     _alarmBPeriod = (p == HOUR_AM) ? AM : PM;
-  }
+  } else
 #else
   UNUSED(name);
 #endif


### PR DESCRIPTION
In case the Alarm name is ALARM_B, this change will avoid getting the Alarm_A
It will only deal with the ALARM which is specified in the `syncAlarmTime(Alarm name) `function
