### PR TITLE
Rtc mix sketch

### DIFF
--- a/examples/mixRTCAlarm/mixRTCAlarm.ino
+++ b/examples/mixRTCAlarm/mixRTCAlarm.ino
@@ -1,0 +1,97 @@
+/*
+  mode Mix RTC alarm
+
+  This sketch shows how to configure the alarm A & B of the RTC in MIX mode
+
+  Creation 12 Dec 2017
+  by Wi6Labs
+  Modified 03 Jul 2020
+  by Frederic Pillon for STMicroelectronics
+  Modified 03 Jul 2023
+  by Francois Ramu for STMicroelectronics
+
+  This example code is in the public domain.
+
+  https://github.com/stm32duino/STM32RTC
+*/
+
+#include <STM32RTC.h>
+
+/* Get the rtc object */
+STM32RTC& rtc = STM32RTC::getInstance();
+
+/* Change these values to set the current initial time */
+const byte seconds = 06;
+const byte minutes = 22;
+const byte hours = 16;
+
+/* Change these values to set the current initial date */
+const byte day = 25;
+const byte month = 6;
+const byte year = 23;
+
+uint32_t timeout;
+
+void setup()
+{
+  Serial.begin(115200);
+
+  // Select RTC clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK.
+  rtc.setClockSource(STM32RTC::LSE_CLOCK);
+
+  /* Configure the MIX mode */ 
+  rtc.setBinaryMode(STM32RTC::MODE_MIX);
+
+  rtc.begin(true, STM32RTC::HOUR_24);
+
+  rtc.setTime(hours, minutes, seconds);
+  rtc.setDate(day, month, year);
+
+  /* wait for a while */
+  delay(200);
+
+  Serial.printf("Start at %02d:%02d:%02d.%03d\r\n",
+          rtc.getHours(), rtc.getMinutes(), rtc.getSeconds(), rtc.getSubSeconds());
+
+  /* Attach the callback function before enabling Interrupt */
+  rtc.attachInterrupt(alarmAMatch);
+
+  /* Program the AlarmA in a 12 seconds */
+  rtc.setAlarmDay(day);
+  rtc.setAlarmTime(hours, minutes, seconds + 12);
+  rtc.enableAlarm(rtc.MATCH_DHHMMSS);
+  Serial.printf("Set Alarm A in 12s (at %02d:%02d:%02d)\r\n",
+          rtc.getAlarmHours(), rtc.getAlarmMinutes(), rtc.getAlarmSeconds());
+
+#ifdef RTC_ALARM_B
+  /* Program ALARM B in 400ms ms from now (keep timeout < 1000ms) */
+  timeout = rtc.getSubSeconds() + 400;
+
+  rtc.attachInterrupt(alarmBMatch, STM32RTC::ALARM_B);
+  rtc.setAlarmSubSeconds(timeout, STM32RTC::ALARM_B);
+  rtc.enableAlarm(rtc.MATCH_SUBSEC, STM32RTC::ALARM_B);
+  Serial.printf("Set Alarm B (in %d ms) at %d ms\r\n", 400,
+  rtc.getAlarmSubSeconds(STM32RTC::ALARM_B));
+#endif
+
+}
+
+void loop()
+{
+
+}
+
+void alarmAMatch(void *data)
+{
+  UNUSED(data);
+  Serial.printf("Alarm A Match at %02d:%02d:%02d\r\n",
+          rtc.getHours(), rtc.getMinutes(), rtc.getSeconds());
+}
+
+void alarmBMatch(void *data)
+{
+  UNUSED(data);
+  Serial.printf("Alarm B Match at %d ms\r\n", rtc.getSubSeconds());
+}
+
+

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -242,13 +242,13 @@ void STM32RTC::enableAlarm(Alarm_Match match, Alarm name)
 #ifdef RTC_ALARM_B
       if (name == ALARM_B) {
         RTC_StartAlarm(::ALARM_B, 0, 0, 0, 0,
-                       (UINT32_MAX - _alarmBSubSeconds), (_alarmBPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       _alarmBSubSeconds, (_alarmBPeriod == AM) ? HOUR_AM : HOUR_PM,
                        static_cast<uint8_t>(31UL));
       } else
 #endif
       {
         RTC_StartAlarm(::ALARM_A, 0, 0, 0, 0,
-                       (UINT32_MAX - _alarmSubSeconds), (_alarmPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       _alarmSubSeconds, (_alarmPeriod == AM) ? HOUR_AM : HOUR_PM,
                        static_cast<uint8_t>(31UL));
       }
       break;
@@ -647,7 +647,7 @@ uint8_t STM32RTC::getAlarmYear(void)
 
 /**
   * @brief  set RTC subseconds.
-  * @param  subseconds: 0-999
+  * @param  subseconds: 0-999 milliseconds
   * @retval none
   */
 void STM32RTC::setSubSeconds(uint32_t subSeconds)
@@ -859,8 +859,7 @@ void STM32RTC::setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year
   */
 void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 {
-
-  if (getBinaryMode() == MODE_MIX) {
+  if (subSeconds < 1000) {
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
@@ -870,19 +869,6 @@ void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 #endif
     {
       _alarmSubSeconds = subSeconds;
-    }
-  } else {
-    if (subSeconds < 1000) {
-#ifdef RTC_ALARM_B
-      if (name == ALARM_B) {
-        _alarmBSubSeconds = subSeconds;
-      }
-#else
-      UNUSED(name);
-#endif
-      {
-        _alarmSubSeconds = subSeconds;
-      }
     }
   }
 }

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -237,13 +237,27 @@ void STM32RTC::enableAlarm(Alarm_Match match, Alarm name)
         RTC_StopAlarm(::ALARM_A);
       }
       break;
+    case MATCH_SUBSEC:
+      /* force _alarmday to 0 to go to the right alarm config in MIX mode */
+#ifdef RTC_ALARM_B
+      if (name == ALARM_B) {
+        RTC_StartAlarm(::ALARM_B, 0, 0, 0, 0,
+                       (UINT32_MAX - _alarmBSubSeconds), (_alarmBPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       static_cast<uint8_t>(31UL));
+      } else
+#endif
+      {
+        RTC_StartAlarm(::ALARM_A, 0, 0, 0, 0,
+                       (UINT32_MAX - _alarmSubSeconds), (_alarmPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       static_cast<uint8_t>(31UL));
+      }
+      break;
     case MATCH_YYMMDDHHMMSS://kept for compatibility
     case MATCH_MMDDHHMMSS:  //kept for compatibility
     case MATCH_DHHMMSS:
     case MATCH_HHMMSS:
     case MATCH_MMSS:
     case MATCH_SS:
-    case MATCH_SUBSEC:
 #ifdef RTC_ALARM_B
       if (name == ALARM_B) {
         RTC_StartAlarm(::ALARM_B, _alarmBDay, _alarmBHours, _alarmBMinutes, _alarmBSeconds,
@@ -845,7 +859,8 @@ void STM32RTC::setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year
   */
 void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 {
-  if (subSeconds < 1000) {
+
+  if (getBinaryMode() == MODE_MIX) {
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
@@ -855,6 +870,19 @@ void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 #endif
     {
       _alarmSubSeconds = subSeconds;
+    }
+  } else {
+    if (subSeconds < 1000) {
+#ifdef RTC_ALARM_B
+      if (name == ALARM_B) {
+        _alarmBSubSeconds = subSeconds;
+      }
+#else
+      UNUSED(name);
+#endif
+      {
+        _alarmSubSeconds = subSeconds;
+      }
     }
   }
 }
@@ -1268,6 +1296,7 @@ bool STM32RTC::isAlarmEnabled(Alarm name)
 void STM32RTC::syncTime(void)
 {
   hourAM_PM_t p = HOUR_AM;
+
   RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, &p);
   _hoursPeriod = (p == HOUR_AM) ? AM : PM;
 }

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -243,6 +243,7 @@ void STM32RTC::enableAlarm(Alarm_Match match, Alarm name)
     case MATCH_HHMMSS:
     case MATCH_MMSS:
     case MATCH_SS:
+    case MATCH_SUBSEC:
 #ifdef RTC_ALARM_B
       if (name == ALARM_B) {
         RTC_StartAlarm(::ALARM_B, _alarmBDay, _alarmBHours, _alarmBMinutes, _alarmBSeconds,

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -63,6 +63,7 @@ void STM32RTC::begin(bool resetTime, Hour_Format format)
 
   _format = format;
   reinit = RTC_init((format == HOUR_12) ? HOUR_FORMAT_12 : HOUR_FORMAT_24,
+                    (_mode == MODE_MIX) ? ::MODE_BINARY_MIX : ((_mode == MODE_BIN) ? ::MODE_BINARY_ONLY : ::MODE_BINARY_NONE),
                     (_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                     (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK
                     , resetTime);
@@ -129,6 +130,26 @@ void STM32RTC::setClockSource(Source_Clock source)
     RTC_SetClockSource((_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                        (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK);
   }
+}
+
+/**
+  * @brief get the Binary Mode.
+  * @retval mode: MODE_BCD, MODE_BIN or MODE_MIX
+  */
+STM32RTC::Binary_Mode STM32RTC::getBinaryMode(void)
+{
+  return _mode;
+}
+
+/**
+  * @brief set the Binary Mode. By default MODE_BCD is selected. This
+  *        method must be called before begin().
+  * @param mode: the RTC mode: MODE_BCD, MODE_BIN or MODE_MIX
+  * @retval None
+  */
+void STM32RTC::setBinaryMode(Binary_Mode mode)
+{
+  _mode = mode;
 }
 
 #if defined(STM32F1xx)

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -93,6 +93,7 @@ class STM32RTC {
 
     enum Alarm_Match : uint8_t {
       MATCH_OFF          = OFF_MSK,                          // Never
+      MATCH_SUBSEC       = SUBSEC_MSK,                       // Every Subsecond
       MATCH_SS           = SS_MSK,                           // Every Minute
       MATCH_MMSS         = SS_MSK | MM_MSK,                  // Every Hour
       MATCH_HHMMSS       = SS_MSK | MM_MSK | HH_MSK,         // Every Day

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -85,6 +85,12 @@ class STM32RTC {
       PM = HOUR_PM
     };
 
+    enum Binary_Mode : uint8_t {
+      MODE_BCD = MODE_BINARY_NONE, /* not used */
+      MODE_BIN = MODE_BINARY_ONLY,
+      MODE_MIX = MODE_BINARY_MIX
+    };
+
     enum Alarm_Match : uint8_t {
       MATCH_OFF          = OFF_MSK,                          // Never
       MATCH_SS           = SS_MSK,                           // Every Minute
@@ -127,6 +133,9 @@ class STM32RTC {
 
     Source_Clock getClockSource(void);
     void setClockSource(Source_Clock source);
+
+    Binary_Mode getBinaryMode(void);
+    void setBinaryMode(Binary_Mode mode);
 
     void enableAlarm(Alarm_Match match, Alarm name = ALARM_A);
     void disableAlarm(Alarm name = ALARM_A);
@@ -237,6 +246,7 @@ class STM32RTC {
     static bool _timeSet;
 
     Hour_Format _format;
+    Binary_Mode _mode;
     AM_PM       _hoursPeriod;
     uint8_t     _hours;
     uint8_t     _minutes;

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -480,13 +480,14 @@ bool RTC_init(hourFormat_t format, binaryMode_t mode, sourceClock_t source, bool
       // In case of RTC source clock change, Backup Domain is reset by RTC_initClock()
       // Save current config before call to RTC_initClock()
       RTC_GetDate(&years, &month, &days, &weekDay);
-      RTC_GetTime(mode, &hours, &minutes, &seconds, &subSeconds, &period);
+      RTC_GetTime(&hours, &minutes, &seconds, &subSeconds, &period);
+
       if (isAlarmASet) {
-        RTC_GetAlarm(mode, ALARM_A, &alarmDay, &alarmHours, &alarmMinutes, &alarmSeconds, &alarmSubseconds, &alarmPeriod, &alarmMask);
+        RTC_GetAlarm(ALARM_A, &alarmDay, &alarmHours, &alarmMinutes, &alarmSeconds, &alarmSubseconds, &alarmPeriod, &alarmMask);
       }
 #ifdef RTC_ALARM_B
       if (isAlarmBSet) {
-        RTC_GetAlarm(mode, ALARM_B, &alarmBDay, &alarmBHours, &alarmBMinutes, &alarmBSeconds, &alarmBSubseconds, &alarmBPeriod, &alarmBMask);
+        RTC_GetAlarm(ALARM_B, &alarmBDay, &alarmBHours, &alarmBMinutes, &alarmBSeconds, &alarmBSubseconds, &alarmBPeriod, &alarmBMask);
       }
 #endif
       // Init RTC clock
@@ -583,14 +584,14 @@ bool RTC_IsConfigured(void)
   * @param hours: 0-12 or 0-23. Depends on the format used.
   * @param minutes: 0-59
   * @param seconds: 0-59
-  * @param subSeconds: 0-999
+  * @param subSeconds: 0-999 (not used)
   * @param period: select HOUR_AM or HOUR_PM period in case RTC is set in 12 hours mode. Else ignored.
   * @retval None
   */
 void RTC_SetTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period)
 {
   RTC_TimeTypeDef RTC_TimeStruct;
-  UNUSED(subSeconds);
+  UNUSED(subSeconds); /* not used (read-only register) */
   /* Ignore time AM PM configuration if in 24 hours format */
   if (initFormat == HOUR_FORMAT_24) {
     period = HOUR_AM;
@@ -656,7 +657,11 @@ void RTC_GetTime(uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *s
     }
 #if defined(RTC_SSR_SS)
     if (subSeconds != NULL) {
-      *subSeconds = ((predivSync - RTC_TimeStruct.SubSeconds) * 1000) / (predivSync + 1);
+      if (initMode == MODE_BINARY_MIX) {
+        *subSeconds = UINT32_MAX - RTC_TimeStruct.SubSeconds;
+      } else {
+        *subSeconds = ((predivSync - RTC_TimeStruct.SubSeconds) * 1000) / (predivSync + 1);
+      }
     }
 #else
     UNUSED(subSeconds);
@@ -815,22 +820,20 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
 #if defined(RTC_ALRMASSR_SSCLR)
       RTC_AlarmStructure.BinaryAutoClr = RTC_ALARMSUBSECONDBIN_AUTOCLR_NO;
 #endif /* RTC_ALRMASSR_SSCLR */
-      RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_NONE;
+      RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_ALL;
 
 #ifdef RTC_ALARM_B
       if (name == ALARM_B)
       {
         /* Expecting RTC_ALARMSUBSECONDBINMASK_NONE for the subsecond mask on ALARM B */
-        RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_ALL;
         RTC_AlarmStructure.AlarmSubSecondMask = mask << RTC_ALRMBSSR_MASKSS_Pos;
       } else
 #endif
       {
         /* Expecting RTC_ALARMSUBSECONDBINMASK_NONE for the subsecond mask on ALARM A */
-        RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_ALL;
         RTC_AlarmStructure.AlarmSubSecondMask = mask << RTC_ALRMASSR_MASKSS_Pos;
       }
-      /* Special case for ALARM B configuration for stm32WL Lorawan */
+      /* Special case for ALARM B configuration when using subsecond reg. in RTC Mix mode */
       RTC_AlarmStructure.AlarmTime.SubSeconds = subSeconds;
     }
 
@@ -927,7 +930,11 @@ void RTC_GetAlarm(alarm_t name, uint8_t *day, uint8_t *hours, uint8_t *minutes, 
     }
 #if defined(RTC_SSR_SS)
     if (subSeconds != NULL) {
-      *subSeconds = ((predivSync - RTC_AlarmStructure.AlarmTime.SubSeconds) * 1000) / (predivSync + 1);
+      if (initMode == MODE_BINARY_MIX) {
+        *subSeconds = UINT32_MAX - RTC_AlarmStructure.AlarmTime.SubSeconds;
+      } else {
+        *subSeconds = ((predivSync - RTC_AlarmStructure.AlarmTime.SubSeconds) * 1000) / (predivSync + 1);
+      }
     }
 #else
     UNUSED(subSeconds);

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -739,11 +739,12 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
     period = HOUR_AM;
   }
 
+  /* Use alarm A by default because it is common to all STM32 HAL */
+  RTC_AlarmStructure.Alarm = name;
+
   if ((((initFormat == HOUR_FORMAT_24) && IS_RTC_HOUR24(hours)) || IS_RTC_HOUR12(hours))
       && IS_RTC_DATE(day) && IS_RTC_MINUTES(minutes) && IS_RTC_SECONDS(seconds)) {
     /* Set RTC_AlarmStructure with calculated values*/
-    /* Use alarm A by default because it is common to all STM32 HAL */
-    RTC_AlarmStructure.Alarm = name;
     RTC_AlarmStructure.AlarmTime.Seconds = seconds;
     RTC_AlarmStructure.AlarmTime.Minutes = minutes;
     RTC_AlarmStructure.AlarmTime.Hours = hours;
@@ -799,6 +800,43 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
     UNUSED(mask);
 #endif /* !STM32F1xx */
 
+    /* Set RTC_Alarm */
+    HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
+    HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
+    HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
+#if defined(RTC_ICSR_BIN)
+  } else if (RtcHandle.Init.BinMode != RTC_BINARY_NONE) {
+    /* We have an SubSecond alarm to set in RTC_BINARY_MIX or RTC_BINARY_ONLY mode */
+#else
+  } else {
+#endif /* RTC_ICSR_BIN */
+#if defined(RTC_SSR_SS)
+    {
+#if defined(RTC_ALRMASSR_SSCLR)
+      RTC_AlarmStructure.BinaryAutoClr = RTC_ALARMSUBSECONDBIN_AUTOCLR_NO;
+#endif /* RTC_ALRMASSR_SSCLR */
+      RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_NONE;
+
+#ifdef RTC_ALARM_B
+      if (name == ALARM_B)
+      {
+        /* Expecting RTC_ALARMSUBSECONDBINMASK_NONE for the subsecond mask on ALARM B */
+        RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_ALL;
+        RTC_AlarmStructure.AlarmSubSecondMask = mask << RTC_ALRMBSSR_MASKSS_Pos;
+      } else
+#endif
+      {
+        /* Expecting RTC_ALARMSUBSECONDBINMASK_NONE for the subsecond mask on ALARM A */
+        RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_ALL;
+        RTC_AlarmStructure.AlarmSubSecondMask = mask << RTC_ALRMASSR_MASKSS_Pos;
+      }
+      /* Special case for ALARM B configuration for stm32WL Lorawan */
+      RTC_AlarmStructure.AlarmTime.SubSeconds = subSeconds;
+    }
+
+#else
+    UNUSED(subSeconds);
+#endif /* RTC_SSR_SS */
     /* Set RTC_Alarm */
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
     HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -76,6 +76,8 @@ static int16_t predivSync = -1;
 static uint32_t prediv = RTC_AUTO_1_SECOND;
 #endif /* !STM32F1xx */
 
+static uint32_t fqce_apre;
+
 static hourFormat_t initFormat = HOUR_FORMAT_12;
 static binaryMode_t initMode = MODE_BINARY_NONE;
 
@@ -371,6 +373,8 @@ static void RTC_computePrediv(int8_t *asynch, int16_t *synch)
     Error_Handler();
   }
   *synch = (int16_t)predivS;
+
+  fqce_apre = clkVal / (*asynch + 1);
 }
 #endif /* !STM32F1xx */
 
@@ -705,8 +709,13 @@ void RTC_GetTime(uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *s
 #if defined(RTC_SSR_SS)
     if (subSeconds != NULL) {
       if (initMode == MODE_BINARY_MIX) {
-        *subSeconds = UINT32_MAX - RTC_TimeStruct.SubSeconds;
+        /* The subsecond is the free-running downcounter, to be converted in milliseconds */
+        *subSeconds = (((UINT32_MAX - RTC_TimeStruct.SubSeconds + 1) & UINT32_MAX)
+                       * 1000) / fqce_apre; /* give one more to compensate the 3.9ms uncertainty */
+        *subSeconds = *subSeconds % 1000; /* nb of milliseconds */
+        /* predivAsync is 0x7F with LSE clock source */
       } else {
+        /* the subsecond register value is converted in millisec */
         *subSeconds = ((predivSync - RTC_TimeStruct.SubSeconds) * 1000) / (predivSync + 1);
       }
     }
@@ -776,7 +785,7 @@ void RTC_GetDate(uint8_t *year, uint8_t *month, uint8_t *day, uint8_t *wday)
   * @param hours: 0-12 or 0-23 depends on the hours mode.
   * @param minutes: 0-59
   * @param seconds: 0-59
-  * @param subSeconds: 0-999
+  * @param subSeconds: 0-999 milliseconds
   * @param period: HOUR_AM or HOUR_PM if in 12 hours mode else ignored.
   * @param mask: configure alarm behavior using alarmMask_t combination.
   *              See AN4579 Table 5 for possible values.
@@ -811,7 +820,12 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
       {
         RTC_AlarmStructure.AlarmSubSecondMask = predivSync_bits << RTC_ALRMASSR_MASKSS_Pos;
       }
-      RTC_AlarmStructure.AlarmTime.SubSeconds = predivSync - (subSeconds * (predivSync + 1)) / 1000;
+      if (initMode == MODE_BINARY_MIX) {
+        /* the subsecond is the millisecond to be converted in a subsecond downcounter value */
+        RTC_AlarmStructure.AlarmTime.SubSeconds = UINT32_MAX - ((subSeconds * fqce_apre) / 1000 + 1);
+      } else {
+        RTC_AlarmStructure.AlarmTime.SubSeconds = predivSync - (subSeconds * (predivSync + 1)) / 1000;
+      }
     } else {
       RTC_AlarmStructure.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_ALL;
     }
@@ -880,8 +894,8 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
         /* Expecting RTC_ALARMSUBSECONDBINMASK_NONE for the subsecond mask on ALARM A */
         RTC_AlarmStructure.AlarmSubSecondMask = mask << RTC_ALRMASSR_MASKSS_Pos;
       }
-      /* Special case for ALARM B configuration when using subsecond reg. in RTC Mix mode */
-      RTC_AlarmStructure.AlarmTime.SubSeconds = subSeconds;
+      /* The subsecond in ms is converted in ticks unit 1 tick is 1000 / fqce_apre */
+      RTC_AlarmStructure.AlarmTime.SubSeconds = UINT32_MAX - (subSeconds * fqce_apre) / 1000;
     }
 
 #else
@@ -978,7 +992,11 @@ void RTC_GetAlarm(alarm_t name, uint8_t *day, uint8_t *hours, uint8_t *minutes, 
 #if defined(RTC_SSR_SS)
     if (subSeconds != NULL) {
       if (initMode == MODE_BINARY_MIX) {
-        *subSeconds = UINT32_MAX - RTC_AlarmStructure.AlarmTime.SubSeconds;
+        /*
+         * The subsecond is the bit SS[14:0] of the ALARM SSR register (not ALARMxINR)
+         * to be converted in milliseconds
+         */
+        *subSeconds = (((0x7fff - RTC_AlarmStructure.AlarmTime.SubSeconds + 1) & 0x7fff) * 1000) / fqce_apre;
       } else {
         *subSeconds = ((predivSync - RTC_AlarmStructure.AlarmTime.SubSeconds) * 1000) / (predivSync + 1);
       }

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -77,7 +77,8 @@ typedef enum {
   are kept for compatibility but are ignored inside enableAlarm(). */
   M_MSK   = 16,
   Y_MSK   = 32,
-  SUBSEC_MSK = 64
+  SUBSEC_MSK = 48,
+  ALL_MSK = 0xFF
 } alarmMask_t;
 
 typedef enum {

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -56,6 +56,12 @@ typedef enum {
 } hourFormat_t;
 
 typedef enum {
+  MODE_BINARY_NONE, /* BCD only */
+  MODE_BINARY_ONLY,
+  MODE_BINARY_MIX
+} binaryMode_t;
+
+typedef enum {
   HOUR_AM,
   HOUR_PM
 } hourAM_PM_t;
@@ -173,7 +179,7 @@ void RTC_getPrediv(int8_t *asynch, int16_t *synch);
 void RTC_setPrediv(int8_t asynch, int16_t synch);
 #endif /* STM32F1xx */
 
-bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
+bool RTC_init(hourFormat_t format, binaryMode_t mode, sourceClock_t source, bool reset);
 void RTC_DeInit(void);
 bool RTC_IsConfigured(void);
 

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -76,7 +76,8 @@ typedef enum {
   /* NOTE: STM32 RTC can't assign a month or a year to an alarm. Those enum
   are kept for compatibility but are ignored inside enableAlarm(). */
   M_MSK   = 16,
-  Y_MSK   = 32
+  Y_MSK   = 32,
+  SUBSEC_MSK = 64
 } alarmMask_t;
 
 typedef enum {


### PR DESCRIPTION
This examples is configuring the RTC in MIX mode
 (binary + calendar BCD) and set Alarm B (if exists)
 few ticks after the current time, whenAlarm A is set
 in calendar mode.
Mainly used on stm32wl55 devices.

Requires https://github.com/stm32duino/STM32RTC/pull/93
