### PR TITLE
Rtc mix in millisec API is using subsecond expressed in milliseconds

### DIFF
--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -242,13 +242,13 @@ void STM32RTC::enableAlarm(Alarm_Match match, Alarm name)
 #ifdef RTC_ALARM_B
       if (name == ALARM_B) {
         RTC_StartAlarm(::ALARM_B, 0, 0, 0, 0,
-                       (UINT32_MAX - _alarmBSubSeconds), (_alarmBPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       _alarmBSubSeconds, (_alarmBPeriod == AM) ? HOUR_AM : HOUR_PM,
                        static_cast<uint8_t>(31UL));
       } else
 #endif
       {
         RTC_StartAlarm(::ALARM_A, 0, 0, 0, 0,
-                       (UINT32_MAX - _alarmSubSeconds), (_alarmPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       _alarmSubSeconds, (_alarmPeriod == AM) ? HOUR_AM : HOUR_PM,
                        static_cast<uint8_t>(31UL));
       }
       break;
@@ -647,7 +647,7 @@ uint8_t STM32RTC::getAlarmYear(void)
 
 /**
   * @brief  set RTC subseconds.
-  * @param  subseconds: 0-999
+  * @param  subseconds: 0-999 milliseconds
   * @retval none
   */
 void STM32RTC::setSubSeconds(uint32_t subSeconds)
@@ -859,8 +859,7 @@ void STM32RTC::setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year
   */
 void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 {
-
-  if (getBinaryMode() == MODE_MIX) {
+  if (subSeconds < 1000) {
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
@@ -870,19 +869,6 @@ void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 #endif
     {
       _alarmSubSeconds = subSeconds;
-    }
-  } else {
-    if (subSeconds < 1000) {
-#ifdef RTC_ALARM_B
-      if (name == ALARM_B) {
-        _alarmBSubSeconds = subSeconds;
-      }
-#else
-      UNUSED(name);
-#endif
-      {
-        _alarmSubSeconds = subSeconds;
-      }
     }
   }
 }

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -237,13 +237,27 @@ void STM32RTC::enableAlarm(Alarm_Match match, Alarm name)
         RTC_StopAlarm(::ALARM_A);
       }
       break;
+    case MATCH_SUBSEC:
+      /* force _alarmday to 0 to go to the right alarm config in MIX mode */
+#ifdef RTC_ALARM_B
+      if (name == ALARM_B) {
+        RTC_StartAlarm(::ALARM_B, 0, 0, 0, 0,
+                       (UINT32_MAX - _alarmBSubSeconds), (_alarmBPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       static_cast<uint8_t>(31UL));
+      } else
+#endif
+      {
+        RTC_StartAlarm(::ALARM_A, 0, 0, 0, 0,
+                       (UINT32_MAX - _alarmSubSeconds), (_alarmPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       static_cast<uint8_t>(31UL));
+      }
+      break;
     case MATCH_YYMMDDHHMMSS://kept for compatibility
     case MATCH_MMDDHHMMSS:  //kept for compatibility
     case MATCH_DHHMMSS:
     case MATCH_HHMMSS:
     case MATCH_MMSS:
     case MATCH_SS:
-    case MATCH_SUBSEC:
 #ifdef RTC_ALARM_B
       if (name == ALARM_B) {
         RTC_StartAlarm(::ALARM_B, _alarmBDay, _alarmBHours, _alarmBMinutes, _alarmBSeconds,
@@ -845,7 +859,8 @@ void STM32RTC::setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year
   */
 void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 {
-  if (subSeconds < 1000) {
+
+  if (getBinaryMode() == MODE_MIX) {
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
@@ -855,6 +870,19 @@ void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 #endif
     {
       _alarmSubSeconds = subSeconds;
+    }
+  } else {
+    if (subSeconds < 1000) {
+#ifdef RTC_ALARM_B
+      if (name == ALARM_B) {
+        _alarmBSubSeconds = subSeconds;
+      }
+#else
+      UNUSED(name);
+#endif
+      {
+        _alarmSubSeconds = subSeconds;
+      }
     }
   }
 }
@@ -1268,6 +1296,7 @@ bool STM32RTC::isAlarmEnabled(Alarm name)
 void STM32RTC::syncTime(void)
 {
   hourAM_PM_t p = HOUR_AM;
+
   RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, &p);
   _hoursPeriod = (p == HOUR_AM) ? AM : PM;
 }

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -243,6 +243,7 @@ void STM32RTC::enableAlarm(Alarm_Match match, Alarm name)
     case MATCH_HHMMSS:
     case MATCH_MMSS:
     case MATCH_SS:
+    case MATCH_SUBSEC:
 #ifdef RTC_ALARM_B
       if (name == ALARM_B) {
         RTC_StartAlarm(::ALARM_B, _alarmBDay, _alarmBHours, _alarmBMinutes, _alarmBSeconds,

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -63,6 +63,7 @@ void STM32RTC::begin(bool resetTime, Hour_Format format)
 
   _format = format;
   reinit = RTC_init((format == HOUR_12) ? HOUR_FORMAT_12 : HOUR_FORMAT_24,
+                    (_mode == MODE_MIX) ? ::MODE_BINARY_MIX : ((_mode == MODE_BIN) ? ::MODE_BINARY_ONLY : ::MODE_BINARY_NONE),
                     (_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                     (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK
                     , resetTime);
@@ -129,6 +130,26 @@ void STM32RTC::setClockSource(Source_Clock source)
     RTC_SetClockSource((_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                        (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK);
   }
+}
+
+/**
+  * @brief get the Binary Mode.
+  * @retval mode: MODE_BCD, MODE_BIN or MODE_MIX
+  */
+STM32RTC::Binary_Mode STM32RTC::getBinaryMode(void)
+{
+  return _mode;
+}
+
+/**
+  * @brief set the Binary Mode. By default MODE_BCD is selected. This
+  *        method must be called before begin().
+  * @param mode: the RTC mode: MODE_BCD, MODE_BIN or MODE_MIX
+  * @retval None
+  */
+void STM32RTC::setBinaryMode(Binary_Mode mode)
+{
+  _mode = mode;
 }
 
 #if defined(STM32F1xx)

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -93,6 +93,7 @@ class STM32RTC {
 
     enum Alarm_Match : uint8_t {
       MATCH_OFF          = OFF_MSK,                          // Never
+      MATCH_SUBSEC       = SUBSEC_MSK,                       // Every Subsecond
       MATCH_SS           = SS_MSK,                           // Every Minute
       MATCH_MMSS         = SS_MSK | MM_MSK,                  // Every Hour
       MATCH_HHMMSS       = SS_MSK | MM_MSK | HH_MSK,         // Every Day

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -85,6 +85,12 @@ class STM32RTC {
       PM = HOUR_PM
     };
 
+    enum Binary_Mode : uint8_t {
+      MODE_BCD = MODE_BINARY_NONE, /* not used */
+      MODE_BIN = MODE_BINARY_ONLY,
+      MODE_MIX = MODE_BINARY_MIX
+    };
+
     enum Alarm_Match : uint8_t {
       MATCH_OFF          = OFF_MSK,                          // Never
       MATCH_SS           = SS_MSK,                           // Every Minute
@@ -127,6 +133,9 @@ class STM32RTC {
 
     Source_Clock getClockSource(void);
     void setClockSource(Source_Clock source);
+
+    Binary_Mode getBinaryMode(void);
+    void setBinaryMode(Binary_Mode mode);
 
     void enableAlarm(Alarm_Match match, Alarm name = ALARM_A);
     void disableAlarm(Alarm name = ALARM_A);
@@ -237,6 +246,7 @@ class STM32RTC {
     static bool _timeSet;
 
     Hour_Format _format;
+    Binary_Mode _mode;
     AM_PM       _hoursPeriod;
     uint8_t     _hours;
     uint8_t     _minutes;

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -56,7 +56,6 @@ extern "C" {
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-static RTC_HandleTypeDef RtcHandle = {0};
 static voidCallbackPtr RTCUserCallback = NULL;
 static void *callbackUserData = NULL;
 #ifdef RTC_ALARM_B
@@ -93,6 +92,9 @@ static inline int _log2(int x)
 {
   return (x > 0) ? (sizeof(int) * 8 - __builtin_clz(x) - 1) : 0;
 }
+
+/* Exported variable --------------------------------------------------------*/
+RTC_HandleTypeDef RtcHandle = {0};
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -737,7 +739,7 @@ void RTC_GetDate(uint8_t *year, uint8_t *month, uint8_t *day, uint8_t *wday)
   */
 void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period, uint8_t mask)
 {
-  RTC_AlarmTypeDef RTC_AlarmStructure;
+  RTC_AlarmTypeDef RTC_AlarmStructure = {0};
 
   /* Ignore time AM PM configuration if in 24 hours format */
   if (initFormat == HOUR_FORMAT_24) {

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -77,7 +77,8 @@ typedef enum {
   are kept for compatibility but are ignored inside enableAlarm(). */
   M_MSK   = 16,
   Y_MSK   = 32,
-  SUBSEC_MSK = 64
+  SUBSEC_MSK = 48,
+  ALL_MSK = 0xFF
 } alarmMask_t;
 
 typedef enum {

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -56,6 +56,12 @@ typedef enum {
 } hourFormat_t;
 
 typedef enum {
+  MODE_BINARY_NONE, /* BCD only */
+  MODE_BINARY_ONLY,
+  MODE_BINARY_MIX
+} binaryMode_t;
+
+typedef enum {
   HOUR_AM,
   HOUR_PM
 } hourAM_PM_t;
@@ -173,7 +179,7 @@ void RTC_getPrediv(int8_t *asynch, int16_t *synch);
 void RTC_setPrediv(int8_t asynch, int16_t synch);
 #endif /* STM32F1xx */
 
-bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
+bool RTC_init(hourFormat_t format, binaryMode_t mode, sourceClock_t source, bool reset);
 void RTC_DeInit(void);
 bool RTC_IsConfigured(void);
 

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -76,7 +76,8 @@ typedef enum {
   /* NOTE: STM32 RTC can't assign a month or a year to an alarm. Those enum
   are kept for compatibility but are ignored inside enableAlarm(). */
   M_MSK   = 16,
-  Y_MSK   = 32
+  Y_MSK   = 32,
+  SUBSEC_MSK = 64
 } alarmMask_t;
 
 typedef enum {


### PR DESCRIPTION
STM32RTC APi has subsecond parameter which is a value in milliseconds

Becasue of the BINARY MIX mode, the parameter _subsecond_ could be confusing as the subsecond register of the RTC is:
- a nb of millisec [0-999] in BCD mode
- a nb of ticks in BIN or MIX mode  -> one tick is one counter unit at the fqce = RTC clock source freq / fqce_apre

For example, in MIX mode, when RTC is clocked by the LSE (32768Hz) the tick is downcounting at 256Hz
(1 tick is ~ 3.9ms ) 
The RTC subsecond register is converted in ms by `  (0xFFFFFFFF - SubSecReg)  * 1000/256 `
And N miliseconds is converted in ticks (count unit) by   `0xFFFFFFFF - (SubSecReg  * 256) /1000`

With this PR, the STM32RTC API is always giving the subsecond parameter in a **nb of milliseconds**.
Especially with functions:
- getSubSeconds() and getTime()
- getAlarmSubSeconds()

- setAlarmSubSeconds()  and setAlarmTime()

- setSubSeconds() and setTime()  (but Subsecond value is ignored there RO register)
