### PR TITLE
harden prediv management and add parameter to set binary mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ _RTC clock source_
 * **`void setClockSource(Source_Clock source)`** : this function must be called before `begin()`.
 
 _RTC Asynchronous and Synchronous prescaler_
-* **`void getPrediv(int8_t *predivA, int16_t *predivS)`** : get (a)synchronous prescaler values if set else computed ones for the current clock source.
-* **`void setPrediv(int8_t predivA, int16_t predivS)`** : set (a)synchronous prescaler values.  This function must be called before `begin()`. Use -1 to reset value and use computed ones. Those values have to match the following conditions: **_1Hz = RTC CLK source / ((predivA + 1) * (predivS + 1))_**
+* **`void getPrediv(uint32_t *predivA, uint32_t *predivS)`** : get (a)synchronous prescaler values if set else computed ones for the current clock source.
+* **`void setPrediv(uint32_t predivA, uint32_t predivS)`** : set (a)synchronous prescaler values.  This function must be called before `begin()`. Use `(PREDIVA_MAX + 1)` and `(PREDIVS_MAX +1)` to reset value and use computed ones. Those values have to match the following conditions: **_1Hz = RTC CLK source / ((predivA + 1) * (predivS + 1))_**
 
 _SubSeconds management_
 * **`uint32_t getSubSeconds(void)`**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ _RTC hours mode (12 or 24)_
 
 _RTC clock source_
 * **`Source_Clock getClockSource(void)`** : get current clock source.
-* **`void setClockSource(Source_Clock source)`** : this function must be called before `begin()`.
+* **`void setClockSource(Source_Clock source, uint32_t predivA, uint32_t predivS)`** : set the clock source (`LSI_CLOCK`, `LSE_CLOCK` or `HSE_CLOCK`) and (a)synchronous prescaler values. This function must be called before `begin()`. Use `(PREDIVA_MAX + 1)` and `(PREDIVS_MAX +1)` to reset value and use computed ones. Those values have to match the following conditions: **_1Hz = RTC CLK source / ((predivA + 1) * (predivS + 1))_**
 
 _RTC Asynchronous and Synchronous prescaler_
 * **`void getPrediv(uint32_t *predivA, uint32_t *predivS)`** : get (a)synchronous prescaler values if set else computed ones for the current clock source.

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -831,7 +831,7 @@ void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
-    }
+    } else
 #else
     UNUSED(name);
 #endif
@@ -854,7 +854,7 @@ void STM32RTC::setAlarmSeconds(uint8_t seconds, Alarm name)
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSeconds = seconds;
-    }
+    } else
 #else
     UNUSED(name);
 #endif
@@ -877,7 +877,7 @@ void STM32RTC::setAlarmMinutes(uint8_t minutes, Alarm name)
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBMinutes = minutes;
-    }
+    } else
 #else
     UNUSED(name);
 #endif

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -117,18 +117,23 @@ STM32RTC::Source_Clock STM32RTC::getClockSource(void)
 }
 
 /**
-  * @brief set the RTC clock source. By default LSI clock is selected. This
-  * method must be called before begin().
+  * @brief set the RTC clock source and user (a)synchronous prescalers values.
+  * @note  By default LSI clock is selected. This method must be called before begin().
   * @param source: clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK
+  * @param  predivA: Asynchronous prescaler value.
+  * @note   Reset value: RTC_AUTO_1_SECOND for STM32F1xx series, else (PREDIVA_MAX + 1)
+  * @param  predivS: Synchronous prescaler value.
+  * @note   Reset value: (PREDIVS_MAX + 1), not used for STM32F1xx series.
   * @retval None
   */
-void STM32RTC::setClockSource(Source_Clock source)
+void STM32RTC::setClockSource(Source_Clock source, uint32_t predivA, uint32_t predivS)
 {
   if (IS_CLOCK_SOURCE(source)) {
     _clockSource = source;
     RTC_SetClockSource((_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                        (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK);
   }
+  RTC_setPrediv(predivA, predivS);
 }
 
 /**
@@ -151,7 +156,7 @@ void STM32RTC::getPrediv(uint32_t *predivA, uint32_t *predivS)
 }
 
 /**
-  * @brief  set user (a)synchronous prescalers value.
+  * @brief  set user (a)synchronous prescalers values.
   * @note   This method must be called before begin().
   * @param  predivA: Asynchronous prescaler value.
   * @note   Reset value: RTC_AUTO_1_SECOND for STM32F1xx series, else (PREDIVA_MAX + 1)
@@ -161,7 +166,7 @@ void STM32RTC::getPrediv(uint32_t *predivA, uint32_t *predivS)
   */
 void STM32RTC::setPrediv(uint32_t predivA, uint32_t predivS)
 {
-  RTC_setPrediv(predivA, predivS);
+  setClockSource(_clockSource, predivA, predivS);
 }
 
 /**

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -63,6 +63,7 @@ void STM32RTC::begin(bool resetTime, Hour_Format format)
 
   _format = format;
   reinit = RTC_init((format == HOUR_12) ? HOUR_FORMAT_12 : HOUR_FORMAT_24,
+                    (_mode == MODE_MIX) ? ::MODE_BINARY_MIX : ((_mode == MODE_BIN) ? ::MODE_BINARY_ONLY : ::MODE_BINARY_NONE),
                     (_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                     (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK
                     , resetTime);
@@ -134,6 +135,26 @@ void STM32RTC::setClockSource(Source_Clock source, uint32_t predivA, uint32_t pr
                        (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK);
   }
   RTC_setPrediv(predivA, predivS);
+}
+
+/**
+  * @brief get the Binary Mode.
+  * @retval mode: MODE_BCD, MODE_BIN or MODE_MIX
+  */
+STM32RTC::Binary_Mode STM32RTC::getBinaryMode(void)
+{
+  return _mode;
+}
+
+/**
+  * @brief set the Binary Mode. By default MODE_BCD is selected. This
+  *        method must be called before begin().
+  * @param mode: the RTC mode: MODE_BCD, MODE_BIN or MODE_MIX
+  * @retval None
+  */
+void STM32RTC::setBinaryMode(Binary_Mode mode)
+{
+  _mode = mode;
 }
 
 /**

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -103,7 +103,7 @@ void STM32RTC::begin(bool resetTime, Hour_Format format)
   */
 void STM32RTC::end(void)
 {
-  RTC_DeInit();
+  RTC_DeInit(true);
   _timeSet = false;
 }
 
@@ -131,60 +131,38 @@ void STM32RTC::setClockSource(Source_Clock source)
   }
 }
 
-#if defined(STM32F1xx)
-/**
-  * @brief  get user asynchronous prescaler value for the current clock source.
-  * @param  predivA: pointer to the current Asynchronous prescaler value
-  * @param  dummy : not used (kept for compatibility reason)
-  * @retval None
-  */
-void STM32RTC::getPrediv(uint32_t *predivA, int16_t *dummy)
-{
-  UNUSED(dummy);
-  RTC_getPrediv(predivA);
-}
-#else
 /**
   * @brief  get user (a)synchronous prescaler values if set else computed
   *         ones for the current clock source.
   * @param  predivA: pointer to the current Asynchronous prescaler value
-  * @param  predivS: pointer to the current Synchronous prescaler value
+  * @param  predivS: pointer to the current Synchronous prescaler value,
+  *         not used for STM32F1xx series.
   * @retval None
   */
-void STM32RTC::getPrediv(int8_t *predivA, int16_t *predivS)
+void STM32RTC::getPrediv(uint32_t *predivA, uint32_t *predivS)
 {
-  if ((predivA != nullptr) && (predivS != nullptr)) {
+  if ((predivA != nullptr)
+#if !defined(STM32F1xx)
+      && (predivS != nullptr)
+#endif /* STM32F1xx */
+     ) {
     RTC_getPrediv(predivA, predivS);
   }
 }
-#endif /* STM32F1xx */
 
-#if defined(STM32F1xx)
-/**
-  * @brief  set user asynchronous prescalers value.
-  * @note   This method must be called before begin().
-  * @param  predivA: Asynchronous prescaler value. Reset value: RTC_AUTO_1_SECOND
-  * @param  dummy : not used (kept for compatibility reason)
-  * @retval None
-  */
-void STM32RTC::setPrediv(uint32_t predivA, int16_t dummy)
-{
-  UNUSED(dummy);
-  RTC_setPrediv(predivA);
-}
-#else
 /**
   * @brief  set user (a)synchronous prescalers value.
   * @note   This method must be called before begin().
-  * @param  predivA: Asynchronous prescaler value. Reset value: -1
-  * @param  predivS: Synchronous prescaler value. Reset value: -1
+  * @param  predivA: Asynchronous prescaler value.
+  * @note   Reset value: RTC_AUTO_1_SECOND for STM32F1xx series, else (PREDIVA_MAX + 1)
+  * @param  predivS: Synchronous prescaler value.
+  * @note   Reset value: (PREDIVS_MAX + 1), not used for STM32F1xx series.
   * @retval None
   */
-void STM32RTC::setPrediv(int8_t predivA, int16_t predivS)
+void STM32RTC::setPrediv(uint32_t predivA, uint32_t predivS)
 {
   RTC_setPrediv(predivA, predivS);
 }
-#endif /* STM32F1xx */
 
 /**
   * @brief enable the RTC alarm.

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -212,13 +212,9 @@ class STM32RTC {
     void setAlarmEpoch(time_t ts, Alarm_Match match, Alarm name);
     void setAlarmEpoch(time_t ts, Alarm_Match match = MATCH_DHHMMSS, uint32_t subSeconds = 0, Alarm name = ALARM_A);
 
-#if defined(STM32F1xx)
-    void getPrediv(uint32_t *predivA, int16_t *dummy = nullptr);
-    void setPrediv(uint32_t predivA, int16_t dummy = 0);
-#else
-    void getPrediv(int8_t *predivA, int16_t *predivS);
-    void setPrediv(int8_t predivA, int16_t predivS);
-#endif /* STM32F1xx */
+    void getPrediv(uint32_t *predivA, uint32_t *predivS);
+    void setPrediv(uint32_t predivA, uint32_t predivS);
+
     bool isConfigured(void)
     {
       return RTC_IsConfigured();
@@ -232,7 +228,10 @@ class STM32RTC {
     friend class STM32LowPower;
 
   private:
-    STM32RTC(void): _clockSource(LSI_CLOCK) {}
+    STM32RTC(void): _clockSource(LSI_CLOCK)
+    {
+      setClockSource(_clockSource);
+    }
 
     static bool _timeSet;
 

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -85,6 +85,12 @@ class STM32RTC {
       PM = HOUR_PM
     };
 
+    enum Binary_Mode : uint8_t {
+      MODE_BCD = MODE_BINARY_NONE, /* not used */
+      MODE_BIN = MODE_BINARY_ONLY,
+      MODE_MIX = MODE_BINARY_MIX
+    };
+
     enum Alarm_Match : uint8_t {
       MATCH_OFF          = OFF_MSK,                          // Never
       MATCH_SS           = SS_MSK,                           // Every Minute
@@ -129,6 +135,9 @@ class STM32RTC {
     void setClockSource(Source_Clock source, uint32_t predivA = (PREDIVA_MAX + 1), uint32_t predivS = (PREDIVS_MAX + 1));
     void getPrediv(uint32_t *predivA, uint32_t *predivS);
     void setPrediv(uint32_t predivA, uint32_t predivS);
+
+    Binary_Mode getBinaryMode(void);
+    void setBinaryMode(Binary_Mode mode);
 
     void enableAlarm(Alarm_Match match, Alarm name = ALARM_A);
     void disableAlarm(Alarm name = ALARM_A);
@@ -227,7 +236,7 @@ class STM32RTC {
     friend class STM32LowPower;
 
   private:
-    STM32RTC(void): _clockSource(LSI_CLOCK)
+    STM32RTC(void): _mode(MODE_BCD), _clockSource(LSI_CLOCK)
     {
       setClockSource(_clockSource);
     }
@@ -235,6 +244,7 @@ class STM32RTC {
     static bool _timeSet;
 
     Hour_Format _format;
+    Binary_Mode _mode;
     AM_PM       _hoursPeriod;
     uint8_t     _hours;
     uint8_t     _minutes;

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -126,7 +126,9 @@ class STM32RTC {
     void end(void);
 
     Source_Clock getClockSource(void);
-    void setClockSource(Source_Clock source);
+    void setClockSource(Source_Clock source, uint32_t predivA = (PREDIVA_MAX + 1), uint32_t predivS = (PREDIVS_MAX + 1));
+    void getPrediv(uint32_t *predivA, uint32_t *predivS);
+    void setPrediv(uint32_t predivA, uint32_t predivS);
 
     void enableAlarm(Alarm_Match match, Alarm name = ALARM_A);
     void disableAlarm(Alarm name = ALARM_A);
@@ -211,9 +213,6 @@ class STM32RTC {
     time_t getAlarmEpoch(uint32_t *subSeconds = nullptr, Alarm name = ALARM_A);
     void setAlarmEpoch(time_t ts, Alarm_Match match, Alarm name);
     void setAlarmEpoch(time_t ts, Alarm_Match match = MATCH_DHHMMSS, uint32_t subSeconds = 0, Alarm name = ALARM_A);
-
-    void getPrediv(uint32_t *predivA, uint32_t *predivS);
-    void setPrediv(uint32_t predivA, uint32_t predivS);
 
     bool isConfigured(void)
     {

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -390,7 +390,7 @@ bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
 #else
   if (!LL_RTC_IsActiveFlag_INITS(RtcHandle.Instance) || reset) {
     // RTC needs initialization
-    RtcHandle.Init.HourFormat = format == HOUR_FORMAT_12 ? RTC_HOURFORMAT_12 : RTC_HOURFORMAT_24;
+    RtcHandle.Init.HourFormat = (format == HOUR_FORMAT_12) ? RTC_HOURFORMAT_12 : RTC_HOURFORMAT_24;
     RtcHandle.Init.OutPut = RTC_OUTPUT_DISABLE;
     RtcHandle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
     RtcHandle.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -56,7 +56,7 @@ extern "C" {
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-static RTC_HandleTypeDef RtcHandle = {0};
+static RTC_HandleTypeDef RtcHandle = {.Instance = RTC};
 static voidCallbackPtr RTCUserCallback = NULL;
 static void *callbackUserData = NULL;
 #ifdef RTC_ALARM_B

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -113,6 +113,7 @@ typedef void(*voidCallbackPtr)(void *);
 #else
 /* for stm32F1 the MAX value is combining PREDIV low & high registers */
 #define PREDIVA_MAX 0xFFFFFU
+#define PREDIVS_MAX 0xFFFFFFFFU /* Unused for STM32F1xx series */
 #endif /* !STM32F1xx */
 
 #if defined(STM32C0xx) || defined(STM32F0xx) || defined(STM32H5xx) || \
@@ -165,16 +166,11 @@ typedef void(*voidCallbackPtr)(void *);
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
 void RTC_SetClockSource(sourceClock_t source);
-#if defined(STM32F1xx)
-void RTC_getPrediv(uint32_t *asynch);
-void RTC_setPrediv(uint32_t asynch);
-#else
-void RTC_getPrediv(int8_t *asynch, int16_t *synch);
-void RTC_setPrediv(int8_t asynch, int16_t synch);
-#endif /* STM32F1xx */
+void RTC_getPrediv(uint32_t *asynch, uint32_t *synch);
+void RTC_setPrediv(uint32_t asynch, uint32_t synch);
 
 bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
-void RTC_DeInit(void);
+void RTC_DeInit(bool reset_cb);
 bool RTC_IsConfigured(void);
 
 void RTC_SetTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period);

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -56,6 +56,12 @@ typedef enum {
 } hourFormat_t;
 
 typedef enum {
+  MODE_BINARY_NONE, /* BCD only */
+  MODE_BINARY_ONLY,
+  MODE_BINARY_MIX
+} binaryMode_t;
+
+typedef enum {
   HOUR_AM,
   HOUR_PM
 } hourAM_PM_t;
@@ -169,7 +175,7 @@ void RTC_SetClockSource(sourceClock_t source);
 void RTC_getPrediv(uint32_t *asynch, uint32_t *synch);
 void RTC_setPrediv(uint32_t asynch, uint32_t synch);
 
-bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
+bool RTC_init(hourFormat_t format, binaryMode_t mode, sourceClock_t source, bool reset);
 void RTC_DeInit(bool reset_cb);
 bool RTC_IsConfigured(void);
 


### PR DESCRIPTION
 * fix: harden prediv management vs clock config

   prediv was not properly computed and some misalignment's could occur depending of the RTC state at init.
* feat: add a parameter to set binary mode

   This is valid when the RTC_BINARY_MIX mode exists in the RTC (bitfield in the RTC ICSR register)
   Set the RTC mode through a setBinaryMode function to be called before begin.