### PR TITLE
Rtc binary only mode subseconds param. expressed in milliseconds 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ _RTC clock source_
 * **`void setClockSource(Source_Clock source)`** : this function must be called before `begin()`.
 
 _RTC Asynchronous and Synchronous prescaler_
-* **`void getPrediv(int8_t *predivA, int16_t *predivS)`** : get (a)synchronous prescaler values if set else computed ones for the current clock source.
-* **`void setPrediv(int8_t predivA, int16_t predivS)`** : set (a)synchronous prescaler values.  This function must be called before `begin()`. Use -1 to reset value and use computed ones. Those values have to match the following conditions: **_1Hz = RTC CLK source / ((predivA + 1) * (predivS + 1))_**
+* **`void getPrediv(uint32_t *predivA, uint32_t *predivS)`** : get (a)synchronous prescaler values if set else computed ones for the current clock source.
+* **`void setPrediv(uint32_t predivA, uint32_t predivS)`** : set (a)synchronous prescaler values.  This function must be called before `begin()`. Use `(PREDIVA_MAX + 1)` and `(PREDIVS_MAX +1)` to reset value and use computed ones. Those values have to match the following conditions: **_1Hz = RTC CLK source / ((predivA + 1) * (predivS + 1))_**
 
 _SubSeconds management_
 * **`uint32_t getSubSeconds(void)`**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ _RTC hours mode (12 or 24)_
 
 _RTC clock source_
 * **`Source_Clock getClockSource(void)`** : get current clock source.
-* **`void setClockSource(Source_Clock source)`** : this function must be called before `begin()`.
+* **`void setClockSource(Source_Clock source, uint32_t predivA, uint32_t predivS)`** : set the clock source (`LSI_CLOCK`, `LSE_CLOCK` or `HSE_CLOCK`) and (a)synchronous prescaler values. This function must be called before `begin()`. Use `(PREDIVA_MAX + 1)` and `(PREDIVS_MAX +1)` to reset value and use computed ones. Those values have to match the following conditions: **_1Hz = RTC CLK source / ((predivA + 1) * (predivS + 1))_**
 
 _RTC Asynchronous and Synchronous prescaler_
 * **`void getPrediv(uint32_t *predivA, uint32_t *predivS)`** : get (a)synchronous prescaler values if set else computed ones for the current clock source.

--- a/examples/bin_onlyRTCAlarm/bin_onlyRTCAlarm.ino
+++ b/examples/bin_onlyRTCAlarm/bin_onlyRTCAlarm.ino
@@ -1,0 +1,83 @@
+/*
+  mode BINary only RTC alarm
+
+  This sketch shows how to configure the alarm A & B of the RTC in BIN mode
+
+  Creation 12 Dec 2017
+  by Wi6Labs
+  Modified 03 Jul 2020
+  by Frederic Pillon for STMicroelectronics
+  Modified 03 sept 2023
+  by Francois Ramu for STMicroelectronics
+
+  This example code is in the public domain.
+
+  https://github.com/stm32duino/STM32RTC
+*/
+
+#include <STM32RTC.h>
+
+/* Get the rtc object */
+STM32RTC& rtc = STM32RTC::getInstance();
+
+uint32_t timeout;
+
+void setup()
+{
+  Serial.begin(115200);
+
+  // Select RTC clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK.
+  rtc.setClockSource(STM32RTC::LSE_CLOCK);
+
+  /* Configure the RTC mode */
+  rtc.setBinaryMode(STM32RTC::MODE_BIN);
+
+  /* in BIN mode time and Date register are not used, only the subsecond register for milisseconds */
+  rtc.begin(true, STM32RTC::HOUR_24);
+
+  /* wait for a while */
+  delay(200);
+
+  /* subsecond expressed in milliseconds */
+  Serial.printf("Start at %d ms \r\n", rtc.getSubSeconds());
+
+  /* Attach the callback function before enabling Interrupt */
+  rtc.attachInterrupt(alarmAMatch);
+
+  /* Program the AlarmA in 12 seconds */
+  rtc.setAlarmTime(0, 0, 0, 12000);
+  rtc.enableAlarm(rtc.MATCH_SUBSEC);
+  Serial.printf("Set Alarm A in 12s (at %d ms)\r\n", rtc.getAlarmSubSeconds());
+
+#ifdef RTC_ALARM_B
+  /* Program ALARM B in 400ms ms from now (keep timeout < 1000ms) */
+  timeout = rtc.getSubSeconds() + 400;
+
+  rtc.attachInterrupt(alarmBMatch, STM32RTC::ALARM_B);
+  rtc.setAlarmSubSeconds(timeout, STM32RTC::ALARM_B);
+  rtc.enableAlarm(rtc.MATCH_SUBSEC, STM32RTC::ALARM_B);
+  Serial.printf("Set Alarm B (in %d ms) at %d ms\r\n", 400,
+  rtc.getAlarmSubSeconds(STM32RTC::ALARM_B));
+#endif
+
+}
+
+void loop()
+{
+
+}
+
+void alarmAMatch(void *data)
+{
+  UNUSED(data);
+  rtc.disableAlarm(STM32RTC::ALARM_A);
+  Serial.printf("Alarm A Match at %d ms \r\n", rtc.getSubSeconds());
+}
+
+void alarmBMatch(void *data)
+{
+  UNUSED(data);
+  rtc.disableAlarm(STM32RTC::ALARM_B); /* Else it will trig again */
+  Serial.printf("Alarm B Match at %d ms\r\n", rtc.getSubSeconds());
+}
+

--- a/examples/mixRTCAlarm/mixRTCAlarm.ino
+++ b/examples/mixRTCAlarm/mixRTCAlarm.ino
@@ -1,0 +1,99 @@
+/*
+  mode Mix RTC alarm
+
+  This sketch shows how to configure the alarm A & B of the RTC in MIX mode
+
+  Creation 12 Dec 2017
+  by Wi6Labs
+  Modified 03 Jul 2020
+  by Frederic Pillon for STMicroelectronics
+  Modified 03 Jul 2023
+  by Francois Ramu for STMicroelectronics
+
+  This example code is in the public domain.
+
+  https://github.com/stm32duino/STM32RTC
+*/
+
+#include <STM32RTC.h>
+
+/* Get the rtc object */
+STM32RTC& rtc = STM32RTC::getInstance();
+
+/* Change these values to set the current initial time */
+const byte seconds = 06;
+const byte minutes = 22;
+const byte hours = 16;
+
+/* Change these values to set the current initial date */
+const byte day = 25;
+const byte month = 6;
+const byte year = 23;
+
+uint32_t timeout;
+
+void setup()
+{
+  Serial.begin(115200);
+
+  // Select RTC clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK.
+  rtc.setClockSource(STM32RTC::LSE_CLOCK);
+
+  /* Configure the RTC mode : STM32RTC::MODE_MIX or STM32RTC::MODE_BCD */
+  rtc.setBinaryMode(STM32RTC::MODE_MIX);
+
+  rtc.begin(true, STM32RTC::HOUR_24);
+
+  rtc.setTime(hours, minutes, seconds);
+  rtc.setDate(day, month, year);
+
+  /* wait for a while */
+  delay(200);
+
+  Serial.printf("Start at %02d:%02d:%02d.%03d\r\n",
+          rtc.getHours(), rtc.getMinutes(), rtc.getSeconds(), rtc.getSubSeconds());
+
+  /* Attach the callback function before enabling Interrupt */
+  rtc.attachInterrupt(alarmAMatch);
+
+  /* Program the AlarmA in a 12 seconds */
+  rtc.setAlarmDay(day);
+  rtc.setAlarmTime(hours, minutes, seconds + 12);
+  rtc.enableAlarm(rtc.MATCH_DHHMMSS);
+  Serial.printf("Set Alarm A in 12s (at %02d:%02d:%02d)\r\n",
+          rtc.getAlarmHours(), rtc.getAlarmMinutes(), rtc.getAlarmSeconds());
+
+#ifdef RTC_ALARM_B
+  /* Program ALARM B in 400ms ms from now (keep timeout < 1000ms) */
+  timeout = rtc.getSubSeconds() + 400;
+
+  rtc.attachInterrupt(alarmBMatch, STM32RTC::ALARM_B);
+  rtc.setAlarmSubSeconds(timeout, STM32RTC::ALARM_B);
+  rtc.enableAlarm(rtc.MATCH_SUBSEC, STM32RTC::ALARM_B);
+  Serial.printf("Set Alarm B (in %d ms) at %d ms\r\n", 400,
+  rtc.getAlarmSubSeconds(STM32RTC::ALARM_B));
+#endif
+
+}
+
+void loop()
+{
+
+}
+
+void alarmAMatch(void *data)
+{
+  UNUSED(data);
+  rtc.disableAlarm(STM32RTC::ALARM_A);
+  Serial.printf("Alarm A Match at %02d:%02d:%02d\r\n",
+          rtc.getHours(), rtc.getMinutes(), rtc.getSeconds());
+}
+
+void alarmBMatch(void *data)
+{
+  UNUSED(data);
+  rtc.disableAlarm(STM32RTC::ALARM_B); /* Else it will trig again */
+  Serial.printf("Alarm B Match at %d ms\r\n", rtc.getSubSeconds());
+}
+
+

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -955,6 +955,18 @@ void STM32RTC::setAlarmHours(uint8_t hours, AM_PM period, Alarm name)
   }
 }
 
+
+/**
+  * @brief  set RTC alarm time.
+  * @param  subSeconds: 0-999 ms or 32bit nb of milliseconds in BIN mode
+  * @param  name: ALARM_A or ALARM_B if exists
+  * @retval none
+  */
+void STM32RTC::setAlarmTime(uint32_t subSeconds, Alarm name)
+{
+  setAlarmTime(0, 0, 0, subSeconds, AM, name);
+}
+
 /**
   * @brief  set RTC alarm time.
   * @param  hours: 0-23

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -340,7 +340,7 @@ void STM32RTC::standbyMode(void)
 
 /**
   * @brief  get RTC subseconds.
-  * @retval return the current subseconds from the RTC.
+  * @retval return the current milliseconds from the RTC.
   */
 uint32_t STM32RTC::getSubSeconds(void)
 {
@@ -388,7 +388,7 @@ uint8_t STM32RTC::getHours(AM_PM *period)
   * @param  hours: pointer to the current hours
   * @param  minutes: pointer to the current minutes
   * @param  seconds: pointer to the current seconds
-  * @param  subSeconds: pointer to the current subSeconds
+  * @param  subSeconds: pointer to the current subSeconds 'in milliseconds)
   * @param  period: optional (default: nullptr)
   *         pointer to the current hour period set in the RTC: AM or PM
   * @retval none
@@ -835,14 +835,25 @@ void STM32RTC::setDate(uint8_t weekDay, uint8_t day, uint8_t month, uint8_t year
 
 /**
   * @brief  set RTC alarm subseconds.
-  * @param  subseconds: 0-999 (in ms)
+  * @param  subseconds: 0-999 (in ms) or 32bit value in BIN mode
   * @param name: optional (default: ALARM_A)
   *        ALARM_A or ALARM_B if exists
   * @retval none
   */
 void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 {
-  if (subSeconds < 1000) {
+  if (_mode == MODE_BIN) {
+#ifdef RTC_ALARM_B
+    if (name == ALARM_B) {
+      _alarmBSubSeconds = subSeconds;
+    }
+#else
+    UNUSED(name);
+#endif
+    {
+      _alarmSubSeconds = subSeconds;
+    }
+  } else if (subSeconds < 1000) {
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
@@ -973,10 +984,10 @@ void STM32RTC::setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uin
 
 /**
   * @brief  set RTC alarm time.
-  * @param  hours: 0-23
-  * @param  minutes: 0-59
-  * @param  seconds: 0-59
-  * @param  subSeconds: 0-999 (optional)
+  * @param  hours: 0-23 (not used in BIN mode)
+  * @param  minutes: 0-59 (not used in BIN mode)
+  * @param  seconds: 0-59 (not used in BIN mode)
+  * @param  subSeconds: 0-999 ms (optional) or 32bit nb of milliseconds in BIN mode
   * @param  period: hour format AM or PM (optional)
   * @param  name: optional (default: ALARM_A)
   *         ALARM_A or ALARM_B if exists

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -846,7 +846,7 @@ void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
-    }
+    } else
 #else
     UNUSED(name);
 #endif
@@ -857,7 +857,7 @@ void STM32RTC::setAlarmSubSeconds(uint32_t subSeconds, Alarm name)
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSubSeconds = subSeconds;
-    }
+    } else
 #else
     UNUSED(name);
 #endif
@@ -880,7 +880,7 @@ void STM32RTC::setAlarmSeconds(uint8_t seconds, Alarm name)
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBSeconds = seconds;
-    }
+    } else
 #else
     UNUSED(name);
 #endif
@@ -903,7 +903,7 @@ void STM32RTC::setAlarmMinutes(uint8_t minutes, Alarm name)
 #ifdef RTC_ALARM_B
     if (name == ALARM_B) {
       _alarmBMinutes = minutes;
-    }
+    } else
 #else
     UNUSED(name);
 #endif
@@ -942,7 +942,7 @@ void STM32RTC::setAlarmHours(uint8_t hours, AM_PM period, Alarm name)
       if (_format == HOUR_12) {
         _alarmBPeriod = period;
       }
-    }
+    } else
 #else
     UNUSED(name);
 #endif

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -220,6 +220,21 @@ void STM32RTC::enableAlarm(Alarm_Match match, Alarm name)
         RTC_StopAlarm(::ALARM_A);
       }
       break;
+    case MATCH_SUBSEC:
+      /* force _alarmday to 0 to go to the right alarm config in MIX mode */
+#ifdef RTC_ALARM_B
+      if (name == ALARM_B) {
+        RTC_StartAlarm(::ALARM_B, 0, 0, 0, 0,
+                       _alarmBSubSeconds, (_alarmBPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       static_cast<uint8_t>(31UL));
+      } else
+#endif
+      {
+        RTC_StartAlarm(::ALARM_A, 0, 0, 0, 0,
+                       _alarmSubSeconds, (_alarmPeriod == AM) ? HOUR_AM : HOUR_PM,
+                       static_cast<uint8_t>(31UL));
+      }
+      break;
     case MATCH_YYMMDDHHMMSS://kept for compatibility
     case MATCH_MMDDHHMMSS:  //kept for compatibility
     case MATCH_DHHMMSS:
@@ -615,7 +630,7 @@ uint8_t STM32RTC::getAlarmYear(void)
 
 /**
   * @brief  set RTC subseconds.
-  * @param  subseconds: 0-999
+  * @param  subseconds: 0-999 milliseconds
   * @retval none
   */
 void STM32RTC::setSubSeconds(uint32_t subSeconds)
@@ -1250,6 +1265,7 @@ bool STM32RTC::isAlarmEnabled(Alarm name)
 void STM32RTC::syncTime(void)
 {
   hourAM_PM_t p = HOUR_AM;
+
   RTC_GetTime(&_hours, &_minutes, &_seconds, &_subSeconds, &p);
   _hoursPeriod = (p == HOUR_AM) ? AM : PM;
 }

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -117,18 +117,23 @@ STM32RTC::Source_Clock STM32RTC::getClockSource(void)
 }
 
 /**
-  * @brief set the RTC clock source. By default LSI clock is selected. This
-  * method must be called before begin().
+  * @brief set the RTC clock source and user (a)synchronous prescalers values.
+  * @note  By default LSI clock is selected. This method must be called before begin().
   * @param source: clock source: LSI_CLOCK, LSE_CLOCK or HSE_CLOCK
+  * @param  predivA: Asynchronous prescaler value.
+  * @note   Reset value: RTC_AUTO_1_SECOND for STM32F1xx series, else (PREDIVA_MAX + 1)
+  * @param  predivS: Synchronous prescaler value.
+  * @note   Reset value: (PREDIVS_MAX + 1), not used for STM32F1xx series.
   * @retval None
   */
-void STM32RTC::setClockSource(Source_Clock source)
+void STM32RTC::setClockSource(Source_Clock source, uint32_t predivA, uint32_t predivS)
 {
   if (IS_CLOCK_SOURCE(source)) {
     _clockSource = source;
     RTC_SetClockSource((_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                        (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK);
   }
+  RTC_setPrediv(predivA, predivS);
 }
 
 /**
@@ -151,7 +156,7 @@ void STM32RTC::getPrediv(uint32_t *predivA, uint32_t *predivS)
 }
 
 /**
-  * @brief  set user (a)synchronous prescalers value.
+  * @brief  set user (a)synchronous prescalers values.
   * @note   This method must be called before begin().
   * @param  predivA: Asynchronous prescaler value.
   * @note   Reset value: RTC_AUTO_1_SECOND for STM32F1xx series, else (PREDIVA_MAX + 1)
@@ -161,7 +166,7 @@ void STM32RTC::getPrediv(uint32_t *predivA, uint32_t *predivS)
   */
 void STM32RTC::setPrediv(uint32_t predivA, uint32_t predivS)
 {
-  RTC_setPrediv(predivA, predivS);
+  setClockSource(_clockSource, predivA, predivS);
 }
 
 /**

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -63,6 +63,7 @@ void STM32RTC::begin(bool resetTime, Hour_Format format)
 
   _format = format;
   reinit = RTC_init((format == HOUR_12) ? HOUR_FORMAT_12 : HOUR_FORMAT_24,
+                    (_mode == MODE_MIX) ? ::MODE_BINARY_MIX : ((_mode == MODE_BIN) ? ::MODE_BINARY_ONLY : ::MODE_BINARY_NONE),
                     (_clockSource == LSE_CLOCK) ? ::LSE_CLOCK :
                     (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK
                     , resetTime);
@@ -134,6 +135,26 @@ void STM32RTC::setClockSource(Source_Clock source, uint32_t predivA, uint32_t pr
                        (_clockSource == HSE_CLOCK) ? ::HSE_CLOCK : ::LSI_CLOCK);
   }
   RTC_setPrediv(predivA, predivS);
+}
+
+/**
+  * @brief get the Binary Mode.
+  * @retval mode: MODE_BCD, MODE_BIN or MODE_MIX
+  */
+STM32RTC::Binary_Mode STM32RTC::getBinaryMode(void)
+{
+  return _mode;
+}
+
+/**
+  * @brief set the Binary Mode. By default MODE_BCD is selected. This
+  *        method must be called before begin().
+  * @param mode: the RTC mode: MODE_BCD, MODE_BIN or MODE_MIX
+  * @retval None
+  */
+void STM32RTC::setBinaryMode(Binary_Mode mode)
+{
+  _mode = mode;
 }
 
 /**

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -103,7 +103,7 @@ void STM32RTC::begin(bool resetTime, Hour_Format format)
   */
 void STM32RTC::end(void)
 {
-  RTC_DeInit();
+  RTC_DeInit(true);
   _timeSet = false;
 }
 
@@ -131,60 +131,38 @@ void STM32RTC::setClockSource(Source_Clock source)
   }
 }
 
-#if defined(STM32F1xx)
-/**
-  * @brief  get user asynchronous prescaler value for the current clock source.
-  * @param  predivA: pointer to the current Asynchronous prescaler value
-  * @param  dummy : not used (kept for compatibility reason)
-  * @retval None
-  */
-void STM32RTC::getPrediv(uint32_t *predivA, int16_t *dummy)
-{
-  UNUSED(dummy);
-  RTC_getPrediv(predivA);
-}
-#else
 /**
   * @brief  get user (a)synchronous prescaler values if set else computed
   *         ones for the current clock source.
   * @param  predivA: pointer to the current Asynchronous prescaler value
-  * @param  predivS: pointer to the current Synchronous prescaler value
+  * @param  predivS: pointer to the current Synchronous prescaler value,
+  *         not used for STM32F1xx series.
   * @retval None
   */
-void STM32RTC::getPrediv(int8_t *predivA, int16_t *predivS)
+void STM32RTC::getPrediv(uint32_t *predivA, uint32_t *predivS)
 {
-  if ((predivA != nullptr) && (predivS != nullptr)) {
+  if ((predivA != nullptr)
+#if !defined(STM32F1xx)
+      && (predivS != nullptr)
+#endif /* STM32F1xx */
+     ) {
     RTC_getPrediv(predivA, predivS);
   }
 }
-#endif /* STM32F1xx */
 
-#if defined(STM32F1xx)
-/**
-  * @brief  set user asynchronous prescalers value.
-  * @note   This method must be called before begin().
-  * @param  predivA: Asynchronous prescaler value. Reset value: RTC_AUTO_1_SECOND
-  * @param  dummy : not used (kept for compatibility reason)
-  * @retval None
-  */
-void STM32RTC::setPrediv(uint32_t predivA, int16_t dummy)
-{
-  UNUSED(dummy);
-  RTC_setPrediv(predivA);
-}
-#else
 /**
   * @brief  set user (a)synchronous prescalers value.
   * @note   This method must be called before begin().
-  * @param  predivA: Asynchronous prescaler value. Reset value: -1
-  * @param  predivS: Synchronous prescaler value. Reset value: -1
+  * @param  predivA: Asynchronous prescaler value.
+  * @note   Reset value: RTC_AUTO_1_SECOND for STM32F1xx series, else (PREDIVA_MAX + 1)
+  * @param  predivS: Synchronous prescaler value.
+  * @note   Reset value: (PREDIVS_MAX + 1), not used for STM32F1xx series.
   * @retval None
   */
-void STM32RTC::setPrediv(int8_t predivA, int16_t predivS)
+void STM32RTC::setPrediv(uint32_t predivA, uint32_t predivS)
 {
   RTC_setPrediv(predivA, predivS);
 }
-#endif /* STM32F1xx */
 
 /**
   * @brief enable the RTC alarm.

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -212,13 +212,9 @@ class STM32RTC {
     void setAlarmEpoch(time_t ts, Alarm_Match match, Alarm name);
     void setAlarmEpoch(time_t ts, Alarm_Match match = MATCH_DHHMMSS, uint32_t subSeconds = 0, Alarm name = ALARM_A);
 
-#if defined(STM32F1xx)
-    void getPrediv(uint32_t *predivA, int16_t *dummy = nullptr);
-    void setPrediv(uint32_t predivA, int16_t dummy = 0);
-#else
-    void getPrediv(int8_t *predivA, int16_t *predivS);
-    void setPrediv(int8_t predivA, int16_t predivS);
-#endif /* STM32F1xx */
+    void getPrediv(uint32_t *predivA, uint32_t *predivS);
+    void setPrediv(uint32_t predivA, uint32_t predivS);
+
     bool isConfigured(void)
     {
       return RTC_IsConfigured();
@@ -232,7 +228,10 @@ class STM32RTC {
     friend class STM32LowPower;
 
   private:
-    STM32RTC(void): _clockSource(LSI_CLOCK) {}
+    STM32RTC(void): _clockSource(LSI_CLOCK)
+    {
+      setClockSource(_clockSource);
+    }
 
     static bool _timeSet;
 

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -93,6 +93,7 @@ class STM32RTC {
 
     enum Alarm_Match : uint8_t {
       MATCH_OFF          = OFF_MSK,                          // Never
+      MATCH_SUBSEC       = SUBSEC_MSK,                       // Every Subsecond
       MATCH_SS           = SS_MSK,                           // Every Minute
       MATCH_MMSS         = SS_MSK | MM_MSK,                  // Every Hour
       MATCH_HHMMSS       = SS_MSK | MM_MSK | HH_MSK,         // Every Day

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -126,7 +126,9 @@ class STM32RTC {
     void end(void);
 
     Source_Clock getClockSource(void);
-    void setClockSource(Source_Clock source);
+    void setClockSource(Source_Clock source, uint32_t predivA = (PREDIVS_MAX + 1), uint32_t predivS = (PREDIVS_MAX + 1));
+    void getPrediv(uint32_t *predivA, uint32_t *predivS);
+    void setPrediv(uint32_t predivA, uint32_t predivS);
 
     void enableAlarm(Alarm_Match match, Alarm name = ALARM_A);
     void disableAlarm(Alarm name = ALARM_A);
@@ -211,9 +213,6 @@ class STM32RTC {
     time_t getAlarmEpoch(uint32_t *subSeconds = nullptr, Alarm name = ALARM_A);
     void setAlarmEpoch(time_t ts, Alarm_Match match, Alarm name);
     void setAlarmEpoch(time_t ts, Alarm_Match match = MATCH_DHHMMSS, uint32_t subSeconds = 0, Alarm name = ALARM_A);
-
-    void getPrediv(uint32_t *predivA, uint32_t *predivS);
-    void setPrediv(uint32_t predivA, uint32_t predivS);
 
     bool isConfigured(void)
     {

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -85,6 +85,12 @@ class STM32RTC {
       PM = HOUR_PM
     };
 
+    enum Binary_Mode : uint8_t {
+      MODE_BCD = MODE_BINARY_NONE, /* not used */
+      MODE_BIN = MODE_BINARY_ONLY,
+      MODE_MIX = MODE_BINARY_MIX
+    };
+
     enum Alarm_Match : uint8_t {
       MATCH_OFF          = OFF_MSK,                          // Never
       MATCH_SS           = SS_MSK,                           // Every Minute
@@ -129,6 +135,9 @@ class STM32RTC {
     void setClockSource(Source_Clock source, uint32_t predivA = (PREDIVS_MAX + 1), uint32_t predivS = (PREDIVS_MAX + 1));
     void getPrediv(uint32_t *predivA, uint32_t *predivS);
     void setPrediv(uint32_t predivA, uint32_t predivS);
+
+    Binary_Mode getBinaryMode(void);
+    void setBinaryMode(Binary_Mode mode);
 
     void enableAlarm(Alarm_Match match, Alarm name = ALARM_A);
     void disableAlarm(Alarm name = ALARM_A);
@@ -227,7 +236,7 @@ class STM32RTC {
     friend class STM32LowPower;
 
   private:
-    STM32RTC(void): _clockSource(LSI_CLOCK)
+    STM32RTC(void): _mode(MODE_BCD), _clockSource(LSI_CLOCK)
     {
       setClockSource(_clockSource);
     }
@@ -235,6 +244,7 @@ class STM32RTC {
     static bool _timeSet;
 
     Hour_Format _format;
+    Binary_Mode _mode;
     AM_PM       _hoursPeriod;
     uint8_t     _hours;
     uint8_t     _minutes;

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -202,6 +202,7 @@ class STM32RTC {
     void setAlarmMinutes(uint8_t minutes, Alarm name = ALARM_A);
     void setAlarmHours(uint8_t hours, Alarm name);
     void setAlarmHours(uint8_t hours, AM_PM period = AM, Alarm name = ALARM_A);
+    void setAlarmTime(uint32_t subSeconds, Alarm name = ALARM_A);
     void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, Alarm name);
     void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, Alarm name);
     void setAlarmTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds = 0, AM_PM period = AM, Alarm name = ALARM_A);

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -390,7 +390,7 @@ bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset)
 #else
   if (!LL_RTC_IsActiveFlag_INITS(RtcHandle.Instance) || reset) {
     // RTC needs initialization
-    RtcHandle.Init.HourFormat = format == HOUR_FORMAT_12 ? RTC_HOURFORMAT_12 : RTC_HOURFORMAT_24;
+    RtcHandle.Init.HourFormat = (format == HOUR_FORMAT_12) ? RTC_HOURFORMAT_12 : RTC_HOURFORMAT_24;
     RtcHandle.Init.OutPut = RTC_OUTPUT_DISABLE;
     RtcHandle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
     RtcHandle.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -813,7 +813,9 @@ void RTC_GetDate(uint8_t *year, uint8_t *month, uint8_t *day, uint8_t *wday)
 void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period, uint8_t mask)
 {
   RTC_AlarmTypeDef RTC_AlarmStructure = {0};
-
+#if !defined(RTC_SSR_SS)
+  UNUSED(subSeconds);
+#endif
   /* Ignore time AM PM configuration if in 24 hours format */
   if (initFormat == HOUR_FORMAT_24) {
     period = HOUR_AM;
@@ -849,8 +851,6 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
     } else {
       RTC_AlarmStructure.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_ALL;
     }
-#else
-    UNUSED(subSeconds);
 #endif /* RTC_SSR_SS */
     if (period == HOUR_PM) {
       RTC_AlarmStructure.AlarmTime.TimeFormat = RTC_HOURFORMAT12_PM;
@@ -880,7 +880,6 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
       }
     }
 #else
-    UNUSED(subSeconds);
     UNUSED(period);
     UNUSED(day);
     UNUSED(mask);
@@ -890,11 +889,12 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
     HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
     HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
+  }
 #if defined(RTC_ICSR_BIN)
-  } else if ((initMode == MODE_BINARY_MIX) || (initMode == MODE_BINARY_ONLY)) {
+  else if ((initMode == MODE_BINARY_MIX) || (initMode == MODE_BINARY_ONLY)) {
     /* We have an SubSecond alarm to set in RTC_BINARY_MIX or RTC_BINARY_ONLY mode */
 #else
-  } else {
+  else {
 #endif /* RTC_ICSR_BIN */
 #if defined(RTC_SSR_SS)
     {
@@ -917,16 +917,14 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
       /* The subsecond in ms is converted in ticks unit 1 tick is 1000 / fqce_apre */
       RTC_AlarmStructure.AlarmTime.SubSeconds = UINT32_MAX - (subSeconds * fqce_apre) / 1000;
     }
-
-#else
-    UNUSED(subSeconds);
 #endif /* RTC_SSR_SS */
     /* Set RTC_Alarm */
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
     HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
     HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
+  }
 #if defined(RTC_ICSR_BIN)
-  } else {
+  else {
     /* We have an SubSecond alarm to set in BCD (RTC_BINARY_NONE) mode */
 #if defined(RTC_SSR_SS)
     {
@@ -947,9 +945,6 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
       }
       RTC_AlarmStructure.AlarmTime.SubSeconds = subSeconds * fqce_apre / 1000;
     }
-
-#else
-    UNUSED(subSeconds);
 #endif /* RTC_SSR_SS */
     /* Set RTC_Alarm */
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
@@ -957,7 +952,6 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
     HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
   }
 #endif /* RTC_ICSR_BIN */
-
 }
 
 /**

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -723,14 +723,18 @@ void RTC_GetTime(uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *s
     }
 #if defined(RTC_SSR_SS)
     if (subSeconds != NULL) {
-      if ((initMode == MODE_BINARY_MIX) || (initMode == MODE_BINARY_ONLY)) {
+      if (initMode == MODE_BINARY_MIX) {
         /* The subsecond is the free-running downcounter, to be converted in milliseconds */
         *subSeconds = (((UINT32_MAX - RTC_TimeStruct.SubSeconds + 1) & UINT32_MAX)
                        * 1000) / fqce_apre; /* give one more to compensate the 3.9ms uncertainty */
-        *subSeconds = *subSeconds % 1000; /* nb of milliseconds */
+        *subSeconds = *subSeconds % 1000; /* nb of milliseconds [0..999] */
         /* predivAsync is 0x7F with LSE clock source */
+      } else if (initMode == MODE_BINARY_ONLY) {
+        /* The subsecond is the free-running downcounter, to be converted in milliseconds */
+        *subSeconds = (((UINT32_MAX - RTC_TimeStruct.SubSeconds + 1) & UINT32_MAX)
+                       * 1000) / fqce_apre; /* give one more to compensate the 3.9ms uncertainty */
       } else {
-        /* the subsecond register value is converted in millisec */
+        /* the subsecond register value is converted in millisec on 32bit*/
         *subSeconds = ((predivSync - RTC_TimeStruct.SubSeconds) * 1000) / (predivSync + 1);
       }
     }

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -56,7 +56,6 @@ extern "C" {
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-static RTC_HandleTypeDef RtcHandle = {.Instance = RTC};
 static voidCallbackPtr RTCUserCallback = NULL;
 static void *callbackUserData = NULL;
 #ifdef RTC_ALARM_B
@@ -96,6 +95,9 @@ static inline int _log2(int x)
 {
   return (x > 0) ? (sizeof(int) * 8 - __builtin_clz(x) - 1) : 0;
 }
+
+/* Exported variable --------------------------------------------------------*/
+RTC_HandleTypeDef RtcHandle = {.Instance = RTC};
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -759,7 +761,7 @@ void RTC_GetDate(uint8_t *year, uint8_t *month, uint8_t *day, uint8_t *wday)
   */
 void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period, uint8_t mask)
 {
-  RTC_AlarmTypeDef RTC_AlarmStructure;
+  RTC_AlarmTypeDef RTC_AlarmStructure = {0};
 
   /* Ignore time AM PM configuration if in 24 hours format */
   if (initFormat == HOUR_FORMAT_24) {

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -56,7 +56,7 @@ extern "C" {
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-static RTC_HandleTypeDef RtcHandle = {0};
+static RTC_HandleTypeDef RtcHandle = {.Instance = RTC};
 static voidCallbackPtr RTCUserCallback = NULL;
 static void *callbackUserData = NULL;
 #ifdef RTC_ALARM_B

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -894,7 +894,7 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
   else if ((initMode == MODE_BINARY_MIX) || (initMode == MODE_BINARY_ONLY)) {
     /* We have an SubSecond alarm to set in RTC_BINARY_MIX or RTC_BINARY_ONLY mode */
 #else
-  else {
+  else { /*  */
 #endif /* RTC_ICSR_BIN */
 #if defined(RTC_SSR_SS)
     {
@@ -917,11 +917,11 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
       /* The subsecond in ms is converted in ticks unit 1 tick is 1000 / fqce_apre */
       RTC_AlarmStructure.AlarmTime.SubSeconds = UINT32_MAX - (subSeconds * fqce_apre) / 1000;
     }
-#endif /* RTC_SSR_SS */
     /* Set RTC_Alarm */
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
     HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
     HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
+#endif /* RTC_SSR_SS */
   }
 #if defined(RTC_ICSR_BIN)
   else {
@@ -945,11 +945,11 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
       }
       RTC_AlarmStructure.AlarmTime.SubSeconds = subSeconds * fqce_apre / 1000;
     }
-#endif /* RTC_SSR_SS */
     /* Set RTC_Alarm */
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
     HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
     HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
+#endif /* RTC_SSR_SS */
   }
 #endif /* RTC_ICSR_BIN */
 }

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -101,6 +101,53 @@ RTC_HandleTypeDef RtcHandle = {.Instance = RTC};
 
 /* Exported functions --------------------------------------------------------*/
 
+/* HAL MSP function used for RTC_Init */
+void HAL_RTC_MspInit(RTC_HandleTypeDef *rtcHandle)
+{
+#if defined(RTC_SCR_CSSRUF)
+  if (rtcHandle->Instance == RTC) {
+    /* In BINARY mode (MIX or ONLY), set the SSR Underflow interrupt */
+    if (rtcHandle->Init.BinMode != RTC_BINARY_NONE) {
+#if defined(STM32WLxx)
+      /* Only the STM32WLxx series has a TAMP_STAMP_LSECSS_SSRU_IRQn */
+      if (HAL_RTCEx_SetSSRU_IT(rtcHandle) != HAL_OK) {
+        Error_Handler();
+      }
+      /* Give init value for the RtcFeatures enable */
+      rtcHandle->IsEnabled.RtcFeatures = 0;
+
+      /* RTC interrupt Init */
+      HAL_NVIC_SetPriority(TAMP_STAMP_LSECSS_SSRU_IRQn, 0, 0);
+      HAL_NVIC_EnableIRQ(TAMP_STAMP_LSECSS_SSRU_IRQn);
+#else
+      /* The STM32U5, STM32H5, STM32L4plus have common RTC interrupt and a SSRU flag */
+      __HAL_RTC_SSRU_ENABLE_IT(rtcHandle, RTC_IT_SSRU);
+#endif /* STM32WLxx */
+    }
+  }
+#else /* RTC_SCR_CSSRUF */
+  UNUSED(rtcHandle);
+#endif /* RTC_SCR_CSSRUF */
+  /* RTC_Alarm_IRQn is enabled when enabling Alarm */
+}
+
+void HAL_RTC_MspDeInit(RTC_HandleTypeDef *rtcHandle)
+{
+
+  if (rtcHandle->Instance == RTC) {
+    /* Peripheral clock disable */
+    __HAL_RCC_RTC_DISABLE();
+    __HAL_RCC_RTCAPB_CLK_DISABLE();
+
+    /* RTC interrupt Deinit */
+#if defined(STM32WLxx)
+    /* Only the STM32WLxx series has a TAMP_STAMP_LSECSS_SSRU_IRQn */
+    HAL_NVIC_DisableIRQ(TAMP_STAMP_LSECSS_SSRU_IRQn);
+#endif /* STM32WLxx */
+    HAL_NVIC_DisableIRQ(RTC_Alarm_IRQn);
+  }
+}
+
 /**
   * @brief Set RTC clock source
   * @param source: RTC clock source: LSE, LSI or HSE

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -78,6 +78,8 @@ static uint32_t predivSync = (PREDIVS_MAX + 1);
 static uint32_t predivAsync = RTC_AUTO_1_SECOND;
 #endif /* !STM32F1xx */
 
+static uint32_t fqce_apre;
+
 static hourFormat_t initFormat = HOUR_FORMAT_12;
 static binaryMode_t initMode = MODE_BINARY_NONE;
 
@@ -335,6 +337,8 @@ static void RTC_computePrediv(uint32_t *asynch, uint32_t *synch)
     Error_Handler();
   }
   *synch = predivS;
+
+  fqce_apre = clkVal / (*asynch + 1);
 }
 #endif /* !STM32F1xx */
 
@@ -597,14 +601,14 @@ bool RTC_IsConfigured(void)
   * @param hours: 0-12 or 0-23. Depends on the format used.
   * @param minutes: 0-59
   * @param seconds: 0-59
-  * @param subSeconds: 0-999
+  * @param subSeconds: 0-999 (not used)
   * @param period: select HOUR_AM or HOUR_PM period in case RTC is set in 12 hours mode. Else ignored.
   * @retval None
   */
 void RTC_SetTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period)
 {
   RTC_TimeTypeDef RTC_TimeStruct;
-  UNUSED(subSeconds);
+  UNUSED(subSeconds); /* not used (read-only register) */
   /* Ignore time AM PM configuration if in 24 hours format */
   if (initFormat == HOUR_FORMAT_24) {
     period = HOUR_AM;
@@ -670,7 +674,16 @@ void RTC_GetTime(uint8_t *hours, uint8_t *minutes, uint8_t *seconds, uint32_t *s
     }
 #if defined(RTC_SSR_SS)
     if (subSeconds != NULL) {
-      *subSeconds = ((predivSync - RTC_TimeStruct.SubSeconds) * 1000) / (predivSync + 1);
+      if (initMode == MODE_BINARY_MIX) {
+        /* The subsecond is the free-running downcounter, to be converted in milliseconds */
+        *subSeconds = (((UINT32_MAX - RTC_TimeStruct.SubSeconds + 1) & UINT32_MAX)
+                       * 1000) / fqce_apre; /* give one more to compensate the 3.9ms uncertainty */
+        *subSeconds = *subSeconds % 1000; /* nb of milliseconds */
+        /* predivAsync is 0x7F with LSE clock source */
+      } else {
+        /* the subsecond register value is converted in millisec */
+        *subSeconds = ((predivSync - RTC_TimeStruct.SubSeconds) * 1000) / (predivSync + 1);
+      }
     }
 #else
     UNUSED(subSeconds);
@@ -738,7 +751,7 @@ void RTC_GetDate(uint8_t *year, uint8_t *month, uint8_t *day, uint8_t *wday)
   * @param hours: 0-12 or 0-23 depends on the hours mode.
   * @param minutes: 0-59
   * @param seconds: 0-59
-  * @param subSeconds: 0-999
+  * @param subSeconds: 0-999 milliseconds
   * @param period: HOUR_AM or HOUR_PM if in 12 hours mode else ignored.
   * @param mask: configure alarm behavior using alarmMask_t combination.
   *              See AN4579 Table 5 for possible values.
@@ -753,11 +766,12 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
     period = HOUR_AM;
   }
 
+  /* Use alarm A by default because it is common to all STM32 HAL */
+  RTC_AlarmStructure.Alarm = name;
+
   if ((((initFormat == HOUR_FORMAT_24) && IS_RTC_HOUR24(hours)) || IS_RTC_HOUR12(hours))
       && IS_RTC_DATE(day) && IS_RTC_MINUTES(minutes) && IS_RTC_SECONDS(seconds)) {
     /* Set RTC_AlarmStructure with calculated values*/
-    /* Use alarm A by default because it is common to all STM32 HAL */
-    RTC_AlarmStructure.Alarm = name;
     RTC_AlarmStructure.AlarmTime.Seconds = seconds;
     RTC_AlarmStructure.AlarmTime.Minutes = minutes;
     RTC_AlarmStructure.AlarmTime.Hours = hours;
@@ -772,7 +786,12 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
       {
         RTC_AlarmStructure.AlarmSubSecondMask = predivSync_bits << RTC_ALRMASSR_MASKSS_Pos;
       }
-      RTC_AlarmStructure.AlarmTime.SubSeconds = predivSync - (subSeconds * (predivSync + 1)) / 1000;
+      if (initMode == MODE_BINARY_MIX) {
+        /* the subsecond is the millisecond to be converted in a subsecond downcounter value */
+        RTC_AlarmStructure.AlarmTime.SubSeconds = UINT32_MAX - ((subSeconds * fqce_apre) / 1000 + 1);
+      } else {
+        RTC_AlarmStructure.AlarmTime.SubSeconds = predivSync - (subSeconds * (predivSync + 1)) / 1000;
+      }
     } else {
       RTC_AlarmStructure.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_ALL;
     }
@@ -813,6 +832,41 @@ void RTC_StartAlarm(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes, u
     UNUSED(mask);
 #endif /* !STM32F1xx */
 
+    /* Set RTC_Alarm */
+    HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
+    HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
+    HAL_NVIC_EnableIRQ(RTC_Alarm_IRQn);
+#if defined(RTC_ICSR_BIN)
+  } else if (RtcHandle.Init.BinMode != RTC_BINARY_NONE) {
+    /* We have an SubSecond alarm to set in RTC_BINARY_MIX or RTC_BINARY_ONLY mode */
+#else
+  } else {
+#endif /* RTC_ICSR_BIN */
+#if defined(RTC_SSR_SS)
+    {
+#if defined(RTC_ALRMASSR_SSCLR)
+      RTC_AlarmStructure.BinaryAutoClr = RTC_ALARMSUBSECONDBIN_AUTOCLR_NO;
+#endif /* RTC_ALRMASSR_SSCLR */
+      RTC_AlarmStructure.AlarmMask = RTC_ALARMMASK_ALL;
+
+#ifdef RTC_ALARM_B
+      if (name == ALARM_B)
+      {
+        /* Expecting RTC_ALARMSUBSECONDBINMASK_NONE for the subsecond mask on ALARM B */
+        RTC_AlarmStructure.AlarmSubSecondMask = mask << RTC_ALRMBSSR_MASKSS_Pos;
+      } else
+#endif
+      {
+        /* Expecting RTC_ALARMSUBSECONDBINMASK_NONE for the subsecond mask on ALARM A */
+        RTC_AlarmStructure.AlarmSubSecondMask = mask << RTC_ALRMASSR_MASKSS_Pos;
+      }
+      /* The subsecond in ms is converted in ticks unit 1 tick is 1000 / fqce_apre */
+      RTC_AlarmStructure.AlarmTime.SubSeconds = UINT32_MAX - (subSeconds * fqce_apre) / 1000;
+    }
+
+#else
+    UNUSED(subSeconds);
+#endif /* RTC_SSR_SS */
     /* Set RTC_Alarm */
     HAL_RTC_SetAlarm_IT(&RtcHandle, &RTC_AlarmStructure, RTC_FORMAT_BIN);
     HAL_NVIC_SetPriority(RTC_Alarm_IRQn, RTC_IRQ_PRIO, RTC_IRQ_SUBPRIO);
@@ -903,7 +957,15 @@ void RTC_GetAlarm(alarm_t name, uint8_t *day, uint8_t *hours, uint8_t *minutes, 
     }
 #if defined(RTC_SSR_SS)
     if (subSeconds != NULL) {
-      *subSeconds = ((predivSync - RTC_AlarmStructure.AlarmTime.SubSeconds) * 1000) / (predivSync + 1);
+      if (initMode == MODE_BINARY_MIX) {
+        /*
+         * The subsecond is the bit SS[14:0] of the ALARM SSR register (not ALARMxINR)
+         * to be converted in milliseconds
+         */
+        *subSeconds = (((0x7fff - RTC_AlarmStructure.AlarmTime.SubSeconds + 1) & 0x7fff) * 1000) / fqce_apre;
+      } else {
+        *subSeconds = ((predivSync - RTC_AlarmStructure.AlarmTime.SubSeconds) * 1000) / (predivSync + 1);
+      }
     }
 #else
     UNUSED(subSeconds);

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -76,7 +76,9 @@ typedef enum {
   /* NOTE: STM32 RTC can't assign a month or a year to an alarm. Those enum
   are kept for compatibility but are ignored inside enableAlarm(). */
   M_MSK   = 16,
-  Y_MSK   = 32
+  Y_MSK   = 32,
+  SUBSEC_MSK = 48,
+  ALL_MSK = 0xFF
 } alarmMask_t;
 
 typedef enum {

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -113,6 +113,7 @@ typedef void(*voidCallbackPtr)(void *);
 #else
 /* for stm32F1 the MAX value is combining PREDIV low & high registers */
 #define PREDIVA_MAX 0xFFFFFU
+#define PREDIVS_MAX 0xFFFFFFFFU /* Unused for STM32F1xx series */
 #endif /* !STM32F1xx */
 
 #if defined(STM32C0xx) || defined(STM32F0xx) || defined(STM32H5xx) || \
@@ -165,16 +166,11 @@ typedef void(*voidCallbackPtr)(void *);
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */
 void RTC_SetClockSource(sourceClock_t source);
-#if defined(STM32F1xx)
-void RTC_getPrediv(uint32_t *asynch);
-void RTC_setPrediv(uint32_t asynch);
-#else
-void RTC_getPrediv(int8_t *asynch, int16_t *synch);
-void RTC_setPrediv(int8_t asynch, int16_t synch);
-#endif /* STM32F1xx */
+void RTC_getPrediv(uint32_t *asynch, uint32_t *synch);
+void RTC_setPrediv(uint32_t asynch, uint32_t synch);
 
 bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
-void RTC_DeInit(void);
+void RTC_DeInit(bool reset_cb);
 bool RTC_IsConfigured(void);
 
 void RTC_SetTime(uint8_t hours, uint8_t minutes, uint8_t seconds, uint32_t subSeconds, hourAM_PM_t period);

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -56,6 +56,12 @@ typedef enum {
 } hourFormat_t;
 
 typedef enum {
+  MODE_BINARY_NONE, /* BCD only */
+  MODE_BINARY_ONLY,
+  MODE_BINARY_MIX
+} binaryMode_t;
+
+typedef enum {
   HOUR_AM,
   HOUR_PM
 } hourAM_PM_t;
@@ -169,7 +175,7 @@ void RTC_SetClockSource(sourceClock_t source);
 void RTC_getPrediv(uint32_t *asynch, uint32_t *synch);
 void RTC_setPrediv(uint32_t asynch, uint32_t synch);
 
-bool RTC_init(hourFormat_t format, sourceClock_t source, bool reset);
+bool RTC_init(hourFormat_t format, binaryMode_t mode, sourceClock_t source, bool reset);
 void RTC_DeInit(bool reset_cb);
 bool RTC_IsConfigured(void);
 


### PR DESCRIPTION
When the RTC is configured in BINARY only mode, only the Subsecond register is used
The getTime is a getSubSeconds with _subSeconds_ parameter as a 32bit number of millliseconds 
The setAlarm is a setAlarmSubSeconds with _subSeconds_ parameter as a 32bit number of millliseconds
The getDate returns 0
The setTime has no effect execpt resetting the subseconds counter.
The setDate has no effect .

based on https://github.com/stm32duino/STM32RTC/pull/93

