### PR TITLE
fix calculation of subsecond conversion in MIX or BIN mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,10 @@ Three RTC functional modes are available:
 
 Any API using the Subsecond parameter is expressed in milliseconds
 whatever the RTC input clock. This parameter is [0..999] in MIX or BCD mode
-and [0..0xFFFFFFFF] in BIN mode. In this configuration, time and date registers
-are not used by the RTC.
+and [0..0xFFFFFFFF] in BIN mode. In BIN only mode, time and date registers are not used
+by the RTC. Thus the getEpoch function is only to be called to get the subsecond [0..0xFFFFFFFF]
+(returned time_t is not valid). The setAlarmEpoch only uses the sub-second [0..0xFFFFFFFF]
+(time_t value is useless).
 
 Refer to the Arduino RTC documentation for the other functions
 http://arduino.cc/en/Reference/RTC

--- a/src/STM32RTC.cpp
+++ b/src/STM32RTC.cpp
@@ -1205,10 +1205,13 @@ void STM32RTC::setAlarmEpoch(time_t ts, Alarm_Match match, uint32_t subSeconds, 
   time_t t = ts;
   struct tm *tmp = gmtime(&t);
 
-  setAlarmDay(tmp->tm_mday, name);
-  setAlarmHours(tmp->tm_hour, name);
-  setAlarmMinutes(tmp->tm_min, name);
-  setAlarmSeconds(tmp->tm_sec, name);
+  /* in BIN only mode, the time_t is not relevant, but only the subSeconds in ms */
+  if (_mode != MODE_BIN) {
+    setAlarmDay(tmp->tm_mday, name);
+    setAlarmHours(tmp->tm_hour, name);
+    setAlarmMinutes(tmp->tm_min, name);
+    setAlarmSeconds(tmp->tm_sec, name);
+  }
   setAlarmSubSeconds(subSeconds, name);
   enableAlarm(match, name);
 }


### PR DESCRIPTION
Depending on the RTC mode, the SSR subsecond register and AlarmSSR
differ when converted to/from a value in milliseconds
Correcting the formula in GetTime, GetAlarm/StartAlarm functions.
Update description (README) for BINary only mode use with getEpoch and setAlarmEpoch
