### PR TITLE
stm32RTC can give the hour Format 24 or 12 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ underflow. Used by STM32LoRaWAN.
 Refer to the Arduino RTC documentation for the other functions
 http://arduino.cc/en/Reference/RTC
 
+### Since STM32RTC version higher than 1.4.0
+_IsFormat_24Hour_
+
+Returns True if the current Hour Format is HOUR_24 else false if Hour format is HOUR_12
+
+
 ## Source
 
 Source files available at:

--- a/src/STM32RTC.h
+++ b/src/STM32RTC.h
@@ -240,6 +240,10 @@ class STM32RTC {
     {
       return RTC_IsConfigured();
     }
+    bool isFormat_24hour(void)
+    {
+      return (_format == HOUR_24);
+    }
     bool isAlarmEnabled(Alarm name = ALARM_A);
     bool isTimeSet(void)
     {


### PR DESCRIPTION
Adding a boolean (true) if the Hour format is 24 Hours.


Fixes https://github.com/stm32duino/STM32RTC/issues/104

sketch example:
  `rtc.isFormat_24hour() ? Serial.println("24 hour format ") : Serial.println("12 hour format");
`