### PR TITLE
Start alarm by subSeconds: Avoid overflow during conversion from ms to ticks.

### DIFF
--- a/src/rtc.c
+++ b/src/rtc.c
@@ -947,14 +947,11 @@ void RTC_StartAlarm64(alarm_t name, uint8_t day, uint8_t hours, uint8_t minutes,
     if ((initMode == MODE_BINARY_ONLY) || (initMode == MODE_BINARY_MIX)) {
       /* We have an SubSecond alarm to set in RTC_BINARY_MIX or RTC_BINARY_ONLY mode */
       /* The subsecond in ms is converted in ticks unit 1 tick is 1000 / fqce_apre
-       * It keeps the subsecond accuracy on 64 bits if needed
+       * For the conversion, we keep the accuracy on 64 bits, since otherwise we might
+       * have an overflow even though the conversion result still fits in 32 bits.
        */
-      if (subSeconds > (uint64_t)UINT32_MAX) {
-        uint64_t tmp = (subSeconds * (uint64_t)(predivSync + 1)) / (uint64_t)1000;
-        RTC_AlarmStructure.AlarmTime.SubSeconds = (uint32_t)UINT32_MAX - (uint32_t)tmp;
-      } else {
-        RTC_AlarmStructure.AlarmTime.SubSeconds = (uint32_t)((uint32_t)UINT32_MAX - (uint32_t)(subSeconds * (predivSync + 1)) / 1000);
-      }
+      uint64_t tmp = (subSeconds * (uint64_t)(predivSync + 1)) / (uint64_t)1000;
+      RTC_AlarmStructure.AlarmTime.SubSeconds = (uint32_t)UINT32_MAX - (uint32_t)tmp;
     } else
 #endif /* RTC_ICSR_BIN */
     {


### PR DESCRIPTION
The issue stm32duino/STM32LoRaWAN#38 describes a bug that occus on LoRaWAN after 4 hours 40 minutes. This PR is the fix for that.

The bug occurs, when an alarm shall be put in place using subseconds for RTC_StartAlarm64(). If the subSeconds value is large enough, a computation in RTC_StartAlarm64() overflows.

E.g. when having predivSync=255, a value of subSeconds=2^24 (still well below UINT32_MAX and thus using the 32bit computation branch) would be multiplied by 256 and result in an overflow during computation. The overflow leads to not putting the right alarm in place.
In fact, 2^24 ms is about 4 hours 40 minutes.